### PR TITLE
put number into measures & fix boolean type

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -84,7 +84,16 @@ export function activate(context: vscode.ExtensionContext) {
                 fetchUsageData().then((ret) => {
                     if (Array.isArray(ret) && ret.length) {
                         ret.forEach((entry) => {
-                            reporter.sendTelemetryEvent("usageData", entry, {});
+                            const props = {};
+                            const measures = {};
+                            for (let name in entry) {
+                                if (typeof entry[name] === "number") {
+                                    measures[name] = entry[name];
+                                } else {
+                                    props[name] = String(entry[name]);
+                                }
+                            }
+                            reporter.sendTelemetryEvent("usageData", props, measures);
                         });
                     }
                 });


### PR DESCRIPTION
1. put numbers in `customMeasurements` field to enable sorting in appinsight

2. fix boolean
in `vscode-extension-telemetry`, before sending data, it pre-process the attributes. it's not correct for boolean type.
```
    /**
     * Validate that an object is of type { [key: string]: string }
     */
    Util.validateStringMap = function (obj) {
        var map;
        if (typeof obj === "object") {
            map = {};
            for (var field in obj) {
                var property = obj[field];
                var propertyType = typeof property;
                if (propertyType !== "string") {
                    if (property && typeof property.toString === "function") {
                        property = property.toString();
                    }
                    else {
                        property = "invalid property type: " + propertyType;
                    }
                }
                map[field] = property.trim(0, Util.MAX_PROPERTY_LENGTH);
            }
        }
        else {
            Logging.info("Invalid properties dropped from payload");
        }
        return map;
    };
```

