### PR TITLE
Update the minimum compatiable VSCode version for supporting uri in Source.path

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "debugger"
   ],
   "engines": {
-    "vscode": "^1.15.0"
+    "vscode": "^1.17.0"
   },
   "license": "SEE LICENSE IN LICENSE.txt",
   "repository": {


### PR DESCRIPTION
this PR (https://github.com/Microsoft/java-debug/pull/58) only works at ^VSCode 1.17.0 

Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>