### PR TITLE
only do rebuild for single file

### DIFF
--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -34,7 +34,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
         return vscode.window.withProgress({location: vscode.ProgressLocation.Window}, (p) => {
             return new Promise((resolve, reject) => {
                 p.report({message: "Auto generating configuration..."});
-                resolveMainClass(folder.uri).then((res: any[]) => {
+                resolveMainClass(folder ? folder.uri : undefined).then((res: any[]) => {
                     let cache;
                     cache = {};
                     const launchConfigs = res.map((item) => {
@@ -86,19 +86,21 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                 await updateDebugSettings();
             }
 
-            try {
-                const buildResult = await vscode.commands.executeCommand(commands.JAVA_BUILD_WORKSPACE);
-                console.log(buildResult);
-            } catch (err) {
-                vscode.window.showErrorMessage("Build failed, please fix build error first.");
-                return config;
-            }
-
             if (Object.keys(config).length === 0) { // No launch.json in current workspace.
                 // check whether it is opened as a folder
                 if (folder !== undefined) {
                     // for opened with folder, return directly.
                     return config;
+                }
+                // only rebuild for single file case before the build error issue is resolved.
+                try {
+                    const buildResult = await vscode.commands.executeCommand(commands.JAVA_BUILD_WORKSPACE, false);
+                    console.log(buildResult);
+                } catch (err) {
+                    const ans = await vscode.window.showErrorMessage("Build failed, do you want to continue?", "Proceed", "Abort");
+                    if (ans !== "Proceed") {
+                        return undefined;
+                    }
                 }
                 // Generate config in memory for single file
                 config.type = "java";
@@ -111,7 +113,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
 
             if (config.request === "launch") {
                 if (!config.mainClass) {
-                    const res = <any[]>(await resolveMainClass(folder.uri));
+                    const res = <any[]>(await resolveMainClass(folder ? folder.uri : undefined));
                     if (res.length === 0) {
                         vscode.window.showErrorMessage(
                             "Cannot resolve main class automatically, please specify the mainClass " +
@@ -223,7 +225,10 @@ function resolveClasspath(mainClass, projectName) {
 }
 
 function resolveMainClass(workspaceUri: vscode.Uri) {
-    return commands.executeJavaLanguageServerCommand(commands.JAVA_RESOLVE_MAINCLASS, workspaceUri.toString());
+    if (workspaceUri) {
+        return commands.executeJavaLanguageServerCommand(commands.JAVA_RESOLVE_MAINCLASS, workspaceUri.toString());
+    }
+    return commands.executeJavaLanguageServerCommand(commands.JAVA_RESOLVE_MAINCLASS);
 }
 
 async function updateDebugSettings() {


### PR DESCRIPTION
Signed-off-by: xuzho <xuzho@microsoft.com>

1. rebuild only for single file
2. fix regression of multi-root
3. for single file, if its build fails, would ask user to choose whether to proceed. currently, if abort the launch for single file, vscode would pop up an error message "cannot read property openconfigfile of undefined", i've opened an [issue](https://github.com/Microsoft/vscode/issues/39080) to track