### PR TITLE
Adopt new vscode debug activation event

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A lightweight Java Debugger based on [Java Debug Server](https://github.com/Micr
 
 ## Requirements
 - JDK (version 1.8.0 or later)
-- VS Code (version 1.17.0 or later)
+- VS Code (version 1.19.0 or later)
 - [Language Support for Java by Red Hat](https://marketplace.visualstudio.com/items?itemName=redhat.java) (version 0.14.0 or later)
 
 ## Install

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "debugger"
   ],
   "engines": {
-    "vscode": "^1.17.0"
+    "vscode": "^1.19.0"
   },
   "license": "SEE LICENSE IN LICENSE.txt",
   "repository": {
@@ -30,7 +30,8 @@
   ],
   "activationEvents": [
     "onLanguage:java",
-    "onDebug"
+    "onDebugInitialConfigurations",
+    "onDebugResolve:java"
   ],
   "main": "./out/src/extension",
   "contributes": {


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

See the bug: https://github.com/Microsoft/vscode-java-debug/issues/142. When debugging the non-java project, the java LS and debug extension is also activated that would annoy non-java users.

Latest vscode (1.19.0) has added a new fine grained activation events to mitigate this issue. See bug discussion https://github.com/Microsoft/vscode/issues/37918 and [1.19.0 release notes](https://code.visualstudio.com/updates/v1_19#_debug-contributions-in-packagejson)