### PR TITLE
auto select java debugger for .java file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
             "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0"
+                "arr-flatten": "^1.0.1"
             }
         },
         "arr-flatten": {
@@ -78,7 +78,7 @@
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
             "dev": true,
             "requires": {
-                "array-uniq": "1.0.3"
+                "array-uniq": "^1.0.1"
             }
         },
         "array-uniq": {
@@ -135,9 +135,9 @@
             "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "esutils": "2.0.2",
-                "js-tokens": "3.0.2"
+                "chalk": "^1.1.3",
+                "esutils": "^2.0.2",
+                "js-tokens": "^3.0.2"
             }
         },
         "balanced-match": {
@@ -153,7 +153,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "tweetnacl": "0.14.5"
+                "tweetnacl": "^0.14.3"
             }
         },
         "beeper": {
@@ -168,7 +168,7 @@
             "integrity": "sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "boom": {
@@ -177,7 +177,7 @@
             "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "brace-expansion": {
@@ -186,7 +186,7 @@
             "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -196,9 +196,9 @@
             "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
             "dev": true,
             "requires": {
-                "expand-range": "1.8.2",
-                "preserve": "0.2.0",
-                "repeat-element": "1.1.2"
+                "expand-range": "^1.8.1",
+                "preserve": "^0.2.0",
+                "repeat-element": "^1.1.2"
             }
         },
         "browser-stdout": {
@@ -225,11 +225,11 @@
             "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
             "dev": true,
             "requires": {
-                "ansi-styles": "2.2.1",
-                "escape-string-regexp": "1.0.2",
-                "has-ansi": "2.0.0",
-                "strip-ansi": "3.0.1",
-                "supports-color": "2.0.0"
+                "ansi-styles": "^2.2.1",
+                "escape-string-regexp": "^1.0.2",
+                "has-ansi": "^2.0.0",
+                "strip-ansi": "^3.0.0",
+                "supports-color": "^2.0.0"
             },
             "dependencies": {
                 "supports-color": {
@@ -264,9 +264,9 @@
             "integrity": "sha1-pikNQT8hemEjL5XkWP84QYz7ARc=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "process-nextick-args": "1.0.7",
-                "through2": "2.0.3"
+                "inherits": "^2.0.1",
+                "process-nextick-args": "^1.0.6",
+                "through2": "^2.0.1"
             }
         },
         "co": {
@@ -287,7 +287,7 @@
             "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
             "dev": true,
             "requires": {
-                "delayed-stream": "1.0.0"
+                "delayed-stream": "~1.0.0"
             }
         },
         "commander": {
@@ -320,8 +320,8 @@
             "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
             "dev": true,
             "requires": {
-                "cross-spawn": "6.0.5",
-                "is-windows": "1.0.2"
+                "cross-spawn": "^6.0.5",
+                "is-windows": "^1.0.0"
             },
             "dependencies": {
                 "is-windows": {
@@ -338,11 +338,11 @@
             "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
             "dev": true,
             "requires": {
-                "nice-try": "1.0.4",
-                "path-key": "2.0.1",
-                "semver": "5.5.0",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             },
             "dependencies": {
                 "semver": {
@@ -359,7 +359,7 @@
             "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1"
+                "boom": "2.x.x"
             }
         },
         "dashdash": {
@@ -368,7 +368,7 @@
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -400,7 +400,7 @@
             "integrity": "sha1-sJJ0O+hCfcYh6gBnzex+cN0Z83s=",
             "dev": true,
             "requires": {
-                "is-obj": "1.0.1"
+                "is-obj": "^1.0.0"
             }
         },
         "defaults": {
@@ -409,7 +409,7 @@
             "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
             "dev": true,
             "requires": {
-                "clone": "1.0.2"
+                "clone": "^1.0.2"
             }
         },
         "delayed-stream": {
@@ -430,7 +430,7 @@
             "integrity": "sha1-STXe39lIhkjgBrASlWbpOGcR6mM=",
             "dev": true,
             "requires": {
-                "fs-exists-sync": "0.1.0"
+                "fs-exists-sync": "^0.1.0"
             }
         },
         "diff": {
@@ -451,7 +451,7 @@
             "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
             "dev": true,
             "requires": {
-                "readable-stream": "1.1.14"
+                "readable-stream": "~1.1.9"
             },
             "dependencies": {
                 "isarray": {
@@ -466,10 +466,10 @@
                     "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -486,10 +486,10 @@
             "integrity": "sha1-ThUWvmiDi8kKSZlPCzmm5ZYL780=",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.3",
-                "stream-shift": "1.0.0"
+                "end-of-stream": "^1.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.0",
+                "stream-shift": "^1.0.0"
             }
         },
         "ecc-jsbn": {
@@ -499,7 +499,7 @@
             "dev": true,
             "optional": true,
             "requires": {
-                "jsbn": "0.1.1"
+                "jsbn": "~0.1.0"
             }
         },
         "end-of-stream": {
@@ -508,7 +508,7 @@
             "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
         },
         "escape-string-regexp": {
@@ -529,13 +529,13 @@
             "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1",
-                "from": "0.1.7",
-                "map-stream": "0.1.0",
+                "duplexer": "~0.1.1",
+                "from": "~0",
+                "map-stream": "~0.1.0",
                 "pause-stream": "0.0.11",
-                "split": "0.3.3",
-                "stream-combiner": "0.0.4",
-                "through": "2.3.8"
+                "split": "0.3",
+                "stream-combiner": "~0.0.4",
+                "through": "~2.3.1"
             }
         },
         "expand-brackets": {
@@ -544,7 +544,7 @@
             "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
             "dev": true,
             "requires": {
-                "is-posix-bracket": "0.1.1"
+                "is-posix-bracket": "^0.1.0"
             }
         },
         "expand-range": {
@@ -553,7 +553,7 @@
             "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
             "dev": true,
             "requires": {
-                "fill-range": "2.2.3"
+                "fill-range": "^2.1.0"
             }
         },
         "expand-tilde": {
@@ -562,7 +562,7 @@
             "integrity": "sha1-C4HrqJflo9MdHD0QL48BRB5VlEk=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.1"
             }
         },
         "extend": {
@@ -577,7 +577,7 @@
             "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
             "dev": true,
             "requires": {
-                "is-extendable": "0.1.1"
+                "is-extendable": "^0.1.0"
             }
         },
         "extglob": {
@@ -586,7 +586,7 @@
             "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
             "dev": true,
             "requires": {
-                "is-extglob": "1.0.0"
+                "is-extglob": "^1.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -609,8 +609,8 @@
             "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "time-stamp": "1.1.0"
+                "chalk": "^1.1.1",
+                "time-stamp": "^1.0.0"
             }
         },
         "fast-deep-equal": {
@@ -625,7 +625,7 @@
             "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
             "dev": true,
             "requires": {
-                "pend": "1.2.0"
+                "pend": "~1.2.0"
             }
         },
         "filename-regex": {
@@ -640,11 +640,11 @@
             "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
             "dev": true,
             "requires": {
-                "is-number": "2.1.0",
-                "isobject": "2.1.0",
-                "randomatic": "1.1.7",
-                "repeat-element": "1.1.2",
-                "repeat-string": "1.6.1"
+                "is-number": "^2.1.0",
+                "isobject": "^2.0.0",
+                "randomatic": "^1.1.3",
+                "repeat-element": "^1.1.2",
+                "repeat-string": "^1.5.2"
             }
         },
         "find-index": {
@@ -659,10 +659,10 @@
             "integrity": "sha1-QAQ5Kee8YK3wt/SCfExudaDeyhI=",
             "dev": true,
             "requires": {
-                "detect-file": "0.1.0",
-                "is-glob": "2.0.1",
-                "micromatch": "2.3.11",
-                "resolve-dir": "0.1.1"
+                "detect-file": "^0.1.0",
+                "is-glob": "^2.0.1",
+                "micromatch": "^2.3.7",
+                "resolve-dir": "^0.1.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -677,7 +677,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -688,11 +688,11 @@
             "integrity": "sha1-s33IRLdqL15wgeiE98CuNE8VNHY=",
             "dev": true,
             "requires": {
-                "expand-tilde": "2.0.2",
-                "is-plain-object": "2.0.4",
-                "object.defaults": "1.1.0",
-                "object.pick": "1.3.0",
-                "parse-filepath": "1.0.1"
+                "expand-tilde": "^2.0.2",
+                "is-plain-object": "^2.0.3",
+                "object.defaults": "^1.1.0",
+                "object.pick": "^1.2.0",
+                "parse-filepath": "^1.0.1"
             },
             "dependencies": {
                 "expand-tilde": {
@@ -701,7 +701,7 @@
                     "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
                     "dev": true,
                     "requires": {
-                        "homedir-polyfill": "1.0.1"
+                        "homedir-polyfill": "^1.0.1"
                     }
                 }
             }
@@ -730,7 +730,7 @@
             "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2"
+                "for-in": "^1.0.1"
             }
         },
         "forever-agent": {
@@ -745,9 +745,9 @@
             "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
             "dev": true,
             "requires": {
-                "asynckit": "0.4.0",
-                "combined-stream": "1.0.5",
-                "mime-types": "2.1.17"
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
             }
         },
         "from": {
@@ -774,10 +774,10 @@
             "integrity": "sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inherits": "2.0.3",
-                "mkdirp": "0.5.1",
-                "rimraf": "2.6.1"
+                "graceful-fs": "^4.1.2",
+                "inherits": "~2.0.0",
+                "mkdirp": ">=0.5 0",
+                "rimraf": "2"
             }
         },
         "gaze": {
@@ -786,7 +786,7 @@
             "integrity": "sha1-QLcJU30k0dRXZ9takIaJ3+aaxE8=",
             "dev": true,
             "requires": {
-                "globule": "0.1.0"
+                "globule": "~0.1.0"
             }
         },
         "generate-function": {
@@ -801,7 +801,7 @@
             "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
             "dev": true,
             "requires": {
-                "is-property": "1.0.2"
+                "is-property": "^1.0.0"
             }
         },
         "getpass": {
@@ -810,7 +810,7 @@
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0"
+                "assert-plus": "^1.0.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -827,8 +827,8 @@
             "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimatch": "0.3.0"
+                "inherits": "2",
+                "minimatch": "0.3"
             }
         },
         "glob-base": {
@@ -837,8 +837,8 @@
             "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
             "dev": true,
             "requires": {
-                "glob-parent": "2.0.0",
-                "is-glob": "2.0.1"
+                "glob-parent": "^2.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "glob-parent": {
@@ -847,7 +847,7 @@
                     "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
                     "dev": true,
                     "requires": {
-                        "is-glob": "2.0.1"
+                        "is-glob": "^2.0.0"
                     }
                 },
                 "is-extglob": {
@@ -862,7 +862,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -873,8 +873,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             }
         },
         "glob-stream": {
@@ -883,14 +883,14 @@
             "integrity": "sha1-pVZlqajM3EGRWofHAeMtTgFvrSI=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "glob": "5.0.15",
-                "glob-parent": "3.1.0",
-                "micromatch": "2.3.11",
-                "ordered-read-streams": "0.3.0",
-                "through2": "0.6.5",
-                "to-absolute-glob": "0.1.1",
-                "unique-stream": "2.2.1"
+                "extend": "^3.0.0",
+                "glob": "^5.0.3",
+                "glob-parent": "^3.0.0",
+                "micromatch": "^2.3.7",
+                "ordered-read-streams": "^0.3.0",
+                "through2": "^0.6.0",
+                "to-absolute-glob": "^0.1.1",
+                "unique-stream": "^2.0.2"
             },
             "dependencies": {
                 "glob": {
@@ -899,11 +899,11 @@
                     "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "isarray": {
@@ -918,7 +918,7 @@
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.8"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "readable-stream": {
@@ -927,10 +927,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -945,8 +945,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 }
             }
@@ -957,7 +957,7 @@
             "integrity": "sha1-uVtKjfdLOcgymLDAXJeLTZo7cQs=",
             "dev": true,
             "requires": {
-                "gaze": "0.5.2"
+                "gaze": "^0.5.1"
             }
         },
         "glob2base": {
@@ -966,7 +966,7 @@
             "integrity": "sha1-nUGbPijxLoOjYhZKJ3BVkiycDVY=",
             "dev": true,
             "requires": {
-                "find-index": "0.1.1"
+                "find-index": "^0.1.1"
             }
         },
         "global-modules": {
@@ -975,8 +975,8 @@
             "integrity": "sha1-6lo77ULG1s6ZWk+KEmm12uIjgo0=",
             "dev": true,
             "requires": {
-                "global-prefix": "0.1.5",
-                "is-windows": "0.2.0"
+                "global-prefix": "^0.1.4",
+                "is-windows": "^0.2.0"
             }
         },
         "global-prefix": {
@@ -985,10 +985,10 @@
             "integrity": "sha1-jTvGuNo8qBEqFg2NSW/wRiv+948=",
             "dev": true,
             "requires": {
-                "homedir-polyfill": "1.0.1",
-                "ini": "1.3.4",
-                "is-windows": "0.2.0",
-                "which": "1.3.0"
+                "homedir-polyfill": "^1.0.0",
+                "ini": "^1.3.4",
+                "is-windows": "^0.2.0",
+                "which": "^1.2.12"
             }
         },
         "globule": {
@@ -997,9 +997,9 @@
             "integrity": "sha1-2cjt3h2nnRJaFRt5UzuXhnY0auU=",
             "dev": true,
             "requires": {
-                "glob": "3.1.21",
-                "lodash": "1.0.2",
-                "minimatch": "0.2.14"
+                "glob": "~3.1.21",
+                "lodash": "~1.0.1",
+                "minimatch": "~0.2.11"
             },
             "dependencies": {
                 "glob": {
@@ -1008,9 +1008,9 @@
                     "integrity": "sha1-0p4KBV3qUTj00H7UDomC6DwgZs0=",
                     "dev": true,
                     "requires": {
-                        "graceful-fs": "1.2.3",
-                        "inherits": "1.0.2",
-                        "minimatch": "0.2.14"
+                        "graceful-fs": "~1.2.0",
+                        "inherits": "1",
+                        "minimatch": "~0.2.11"
                     }
                 },
                 "graceful-fs": {
@@ -1037,8 +1037,8 @@
                     "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
                     "dev": true,
                     "requires": {
-                        "lru-cache": "2.7.3",
-                        "sigmund": "1.0.1"
+                        "lru-cache": "2",
+                        "sigmund": "~1.0.0"
                     }
                 }
             }
@@ -1049,7 +1049,7 @@
             "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "graceful-fs": {
@@ -1070,19 +1070,19 @@
             "integrity": "sha1-VxzkWSjdQK9lFPxAEYZgFsE4RbQ=",
             "dev": true,
             "requires": {
-                "archy": "1.0.0",
-                "chalk": "1.1.3",
-                "deprecated": "0.0.1",
-                "gulp-util": "3.0.8",
-                "interpret": "1.0.3",
-                "liftoff": "2.3.0",
-                "minimist": "1.2.0",
-                "orchestrator": "0.3.8",
-                "pretty-hrtime": "1.0.3",
-                "semver": "4.3.6",
-                "tildify": "1.2.0",
-                "v8flags": "2.1.1",
-                "vinyl-fs": "0.3.14"
+                "archy": "^1.0.0",
+                "chalk": "^1.0.0",
+                "deprecated": "^0.0.1",
+                "gulp-util": "^3.0.0",
+                "interpret": "^1.0.0",
+                "liftoff": "^2.1.0",
+                "minimist": "^1.1.0",
+                "orchestrator": "^0.3.0",
+                "pretty-hrtime": "^1.0.0",
+                "semver": "^4.1.0",
+                "tildify": "^1.0.0",
+                "v8flags": "^2.0.2",
+                "vinyl-fs": "^0.3.0"
             },
             "dependencies": {
                 "clone": {
@@ -1097,10 +1097,10 @@
                     "integrity": "sha1-xstz0yJsHv7wTePFbQEvAzd+4V8=",
                     "dev": true,
                     "requires": {
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "2.0.10",
-                        "once": "1.4.0"
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^2.0.1",
+                        "once": "^1.3.0"
                     }
                 },
                 "glob-stream": {
@@ -1109,12 +1109,12 @@
                     "integrity": "sha1-kXCl8St5Awb9/lmPMT+PeVT9FDs=",
                     "dev": true,
                     "requires": {
-                        "glob": "4.5.3",
-                        "glob2base": "0.0.12",
-                        "minimatch": "2.0.10",
-                        "ordered-read-streams": "0.1.0",
-                        "through2": "0.6.5",
-                        "unique-stream": "1.0.0"
+                        "glob": "^4.3.1",
+                        "glob2base": "^0.0.12",
+                        "minimatch": "^2.0.1",
+                        "ordered-read-streams": "^0.1.0",
+                        "through2": "^0.6.1",
+                        "unique-stream": "^1.0.0"
                     }
                 },
                 "graceful-fs": {
@@ -1123,7 +1123,7 @@
                     "integrity": "sha1-dhPHeKGv6mLyXGMKCG1/Osu92Bg=",
                     "dev": true,
                     "requires": {
-                        "natives": "1.1.0"
+                        "natives": "^1.1.0"
                     }
                 },
                 "isarray": {
@@ -1138,7 +1138,7 @@
                     "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.8"
+                        "brace-expansion": "^1.0.0"
                     }
                 },
                 "minimist": {
@@ -1159,10 +1159,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "semver": {
@@ -1183,8 +1183,8 @@
                     "integrity": "sha1-hbiGLzhEtabV7IRnqTWYFzo295Q=",
                     "dev": true,
                     "requires": {
-                        "first-chunk-stream": "1.0.0",
-                        "is-utf8": "0.2.1"
+                        "first-chunk-stream": "^1.0.0",
+                        "is-utf8": "^0.2.0"
                     }
                 },
                 "through2": {
@@ -1193,8 +1193,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 },
                 "unique-stream": {
@@ -1209,8 +1209,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 },
                 "vinyl-fs": {
@@ -1219,14 +1219,14 @@
                     "integrity": "sha1-mmhRzhysHBzqX+hsCTHWIMLPqeY=",
                     "dev": true,
                     "requires": {
-                        "defaults": "1.0.3",
-                        "glob-stream": "3.1.18",
-                        "glob-watcher": "0.0.6",
-                        "graceful-fs": "3.0.11",
-                        "mkdirp": "0.5.1",
-                        "strip-bom": "1.0.0",
-                        "through2": "0.6.5",
-                        "vinyl": "0.4.6"
+                        "defaults": "^1.0.0",
+                        "glob-stream": "^3.1.5",
+                        "glob-watcher": "^0.0.6",
+                        "graceful-fs": "^3.0.0",
+                        "mkdirp": "^0.5.0",
+                        "strip-bom": "^1.0.0",
+                        "through2": "^0.6.1",
+                        "vinyl": "^0.4.0"
                     }
                 }
             }
@@ -1237,9 +1237,9 @@
             "integrity": "sha1-AMOQuSigeZslGsz2MaoJ4BzGKZw=",
             "dev": true,
             "requires": {
-                "deep-assign": "1.0.0",
-                "stat-mode": "0.2.2",
-                "through2": "2.0.3"
+                "deep-assign": "^1.0.0",
+                "stat-mode": "^0.2.0",
+                "through2": "^2.0.0"
             }
         },
         "gulp-filter": {
@@ -1248,9 +1248,9 @@
             "integrity": "sha1-XYf2YuMX5YOe92UOYg5skAj/ktA=",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "multimatch": "2.1.0",
-                "streamfilter": "1.0.5"
+                "gulp-util": "^3.0.6",
+                "multimatch": "^2.0.0",
+                "streamfilter": "^1.0.5"
             }
         },
         "gulp-remote-src": {
@@ -1259,11 +1259,11 @@
             "integrity": "sha1-VyjP1kNDPdSEXd7wlp8PlxoqtKE=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "node.extend": "1.1.6",
-                "request": "2.79.0",
-                "through2": "2.0.3",
-                "vinyl": "2.0.2"
+                "event-stream": "~3.3.4",
+                "node.extend": "~1.1.2",
+                "request": "~2.79.0",
+                "through2": "~2.0.3",
+                "vinyl": "~2.0.1"
             },
             "dependencies": {
                 "clone-stats": {
@@ -1284,26 +1284,26 @@
                     "integrity": "sha1-Tf5b9r6LjNw3/Pk+BLZVd3InEN4=",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.11.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "2.0.6",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.17",
-                        "oauth-sign": "0.8.2",
-                        "qs": "6.3.2",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.4.3",
-                        "uuid": "3.1.0"
+                        "aws-sign2": "~0.6.0",
+                        "aws4": "^1.2.1",
+                        "caseless": "~0.11.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.0",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.1.1",
+                        "har-validator": "~2.0.6",
+                        "hawk": "~3.1.3",
+                        "http-signature": "~1.1.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.7",
+                        "oauth-sign": "~0.8.1",
+                        "qs": "~6.3.0",
+                        "stringstream": "~0.0.4",
+                        "tough-cookie": "~2.3.0",
+                        "tunnel-agent": "~0.4.1",
+                        "uuid": "^3.0.0"
                     }
                 },
                 "vinyl": {
@@ -1312,13 +1312,13 @@
                     "integrity": "sha1-CjcT2NTpIhxY8QyhbAEWyeJe2nw=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.2",
-                        "clone-buffer": "1.0.0",
-                        "clone-stats": "1.0.0",
-                        "cloneable-readable": "1.0.0",
-                        "is-stream": "1.1.0",
-                        "remove-trailing-separator": "1.0.2",
-                        "replace-ext": "1.0.0"
+                        "clone": "^1.0.0",
+                        "clone-buffer": "^1.0.0",
+                        "clone-stats": "^1.0.0",
+                        "cloneable-readable": "^1.0.0",
+                        "is-stream": "^1.1.0",
+                        "remove-trailing-separator": "^1.0.1",
+                        "replace-ext": "^1.0.0"
                     }
                 }
             }
@@ -1329,11 +1329,11 @@
             "integrity": "sha1-uG/zSdgBzrVuHZ59x7vLS33uYAw=",
             "dev": true,
             "requires": {
-                "convert-source-map": "1.5.0",
-                "graceful-fs": "4.1.11",
-                "strip-bom": "2.0.0",
-                "through2": "2.0.3",
-                "vinyl": "1.2.0"
+                "convert-source-map": "^1.1.1",
+                "graceful-fs": "^4.1.2",
+                "strip-bom": "^2.0.0",
+                "through2": "^2.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "vinyl": {
@@ -1342,8 +1342,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.2",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -1355,10 +1355,10 @@
             "integrity": "sha1-wWUyBzLRks5W/ZQnH/oSMjS/KuA=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "mkdirp": "0.5.1",
-                "queue": "3.1.0",
-                "vinyl-fs": "2.4.4"
+                "event-stream": "^3.3.1",
+                "mkdirp": "^0.5.1",
+                "queue": "^3.1.0",
+                "vinyl-fs": "^2.4.3"
             }
         },
         "gulp-tslint": {
@@ -1367,9 +1367,9 @@
             "integrity": "sha1-4PQxlLRz1+drtFpY/oxg59/jvrI=",
             "dev": true,
             "requires": {
-                "gulp-util": "3.0.8",
-                "map-stream": "0.0.7",
-                "through": "2.3.8"
+                "gulp-util": "~3.0.8",
+                "map-stream": "~0.0.7",
+                "through": "~2.3.8"
             },
             "dependencies": {
                 "map-stream": {
@@ -1386,11 +1386,11 @@
             "integrity": "sha1-1r3v3n6ajgVMnxYjhaB4LEvnQAA=",
             "dev": true,
             "requires": {
-                "event-stream": "3.3.4",
-                "gulp-util": "3.0.8",
-                "streamifier": "0.1.1",
-                "tar": "2.2.1",
-                "through2": "2.0.3"
+                "event-stream": "~3.3.4",
+                "gulp-util": "~3.0.8",
+                "streamifier": "~0.1.1",
+                "tar": "^2.2.1",
+                "through2": "~2.0.3"
             }
         },
         "gulp-util": {
@@ -1399,24 +1399,24 @@
             "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-uniq": "1.0.3",
-                "beeper": "1.1.1",
-                "chalk": "1.1.3",
-                "dateformat": "2.0.0",
-                "fancy-log": "1.3.0",
-                "gulplog": "1.0.0",
-                "has-gulplog": "0.1.0",
-                "lodash._reescape": "3.0.0",
-                "lodash._reevaluate": "3.0.0",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.template": "3.6.2",
-                "minimist": "1.2.0",
-                "multipipe": "0.1.2",
-                "object-assign": "3.0.0",
+                "array-differ": "^1.0.0",
+                "array-uniq": "^1.0.2",
+                "beeper": "^1.0.0",
+                "chalk": "^1.0.0",
+                "dateformat": "^2.0.0",
+                "fancy-log": "^1.1.0",
+                "gulplog": "^1.0.0",
+                "has-gulplog": "^0.1.0",
+                "lodash._reescape": "^3.0.0",
+                "lodash._reevaluate": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.template": "^3.0.0",
+                "minimist": "^1.1.0",
+                "multipipe": "^0.1.2",
+                "object-assign": "^3.0.0",
                 "replace-ext": "0.0.1",
-                "through2": "2.0.3",
-                "vinyl": "0.5.3"
+                "through2": "^2.0.0",
+                "vinyl": "^0.5.0"
             },
             "dependencies": {
                 "minimist": {
@@ -1433,7 +1433,7 @@
             "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
             "dev": true,
             "requires": {
-                "glogg": "1.0.0"
+                "glogg": "^1.0.0"
             }
         },
         "har-validator": {
@@ -1442,10 +1442,10 @@
             "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
             "dev": true,
             "requires": {
-                "chalk": "1.1.3",
-                "commander": "2.11.0",
-                "is-my-json-valid": "2.16.1",
-                "pinkie-promise": "2.0.1"
+                "chalk": "^1.1.1",
+                "commander": "^2.9.0",
+                "is-my-json-valid": "^2.12.4",
+                "pinkie-promise": "^2.0.0"
             },
             "dependencies": {
                 "commander": {
@@ -1462,7 +1462,7 @@
             "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "has-gulplog": {
@@ -1471,7 +1471,7 @@
             "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
             "dev": true,
             "requires": {
-                "sparkles": "1.0.0"
+                "sparkles": "^1.0.0"
             }
         },
         "hawk": {
@@ -1480,10 +1480,10 @@
             "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
             "dev": true,
             "requires": {
-                "boom": "2.10.1",
-                "cryptiles": "2.0.5",
-                "hoek": "2.16.3",
-                "sntp": "1.0.9"
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
             }
         },
         "he": {
@@ -1504,7 +1504,7 @@
             "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
             "dev": true,
             "requires": {
-                "parse-passwd": "1.0.0"
+                "parse-passwd": "^1.0.0"
             }
         },
         "http-signature": {
@@ -1513,9 +1513,9 @@
             "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
             "dev": true,
             "requires": {
-                "assert-plus": "0.2.0",
-                "jsprim": "1.4.1",
-                "sshpk": "1.13.1"
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
             }
         },
         "inflight": {
@@ -1524,8 +1524,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -1558,8 +1558,8 @@
             "integrity": "sha1-IN5p89uULvLYe5wto28XIjWxtes=",
             "dev": true,
             "requires": {
-                "is-relative": "0.2.1",
-                "is-windows": "0.2.0"
+                "is-relative": "^0.2.1",
+                "is-windows": "^0.2.0"
             }
         },
         "is-buffer": {
@@ -1580,7 +1580,7 @@
             "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
             "dev": true,
             "requires": {
-                "is-primitive": "2.0.0"
+                "is-primitive": "^2.0.0"
             }
         },
         "is-extendable": {
@@ -1601,7 +1601,7 @@
             "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.0"
             }
         },
         "is-my-json-valid": {
@@ -1610,10 +1610,10 @@
             "integrity": "sha1-WoRnd+LCYg0eaRBOXToDsfYIjxE=",
             "dev": true,
             "requires": {
-                "generate-function": "2.0.0",
-                "generate-object-property": "1.2.0",
-                "jsonpointer": "4.0.1",
-                "xtend": "4.0.1"
+                "generate-function": "^2.0.0",
+                "generate-object-property": "^1.1.0",
+                "jsonpointer": "^4.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "is-number": {
@@ -1622,7 +1622,7 @@
             "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             }
         },
         "is-obj": {
@@ -1634,10 +1634,10 @@
         "is-plain-object": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-            "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+            "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -1672,7 +1672,7 @@
             "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
             "dev": true,
             "requires": {
-                "is-unc-path": "0.1.2"
+                "is-unc-path": "^0.1.1"
             }
         },
         "is-stream": {
@@ -1693,7 +1693,7 @@
             "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
             "dev": true,
             "requires": {
-                "unc-path-regex": "0.1.2"
+                "unc-path-regex": "^0.1.0"
             }
         },
         "is-utf8": {
@@ -1796,7 +1796,7 @@
             "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "json-stringify-safe": {
@@ -1843,7 +1843,7 @@
             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
             "dev": true,
             "requires": {
-                "is-buffer": "1.1.5"
+                "is-buffer": "^1.1.5"
             }
         },
         "lazystream": {
@@ -1852,7 +1852,7 @@
             "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.5"
             }
         },
         "liftoff": {
@@ -1861,15 +1861,15 @@
             "integrity": "sha1-qY8v9nGD2Lp8+soQVIvX/wVQs4U=",
             "dev": true,
             "requires": {
-                "extend": "3.0.1",
-                "findup-sync": "0.4.3",
-                "fined": "1.1.0",
-                "flagged-respawn": "0.3.2",
-                "lodash.isplainobject": "4.0.6",
-                "lodash.isstring": "4.0.1",
-                "lodash.mapvalues": "4.6.0",
-                "rechoir": "0.6.2",
-                "resolve": "1.4.0"
+                "extend": "^3.0.0",
+                "findup-sync": "^0.4.2",
+                "fined": "^1.0.1",
+                "flagged-respawn": "^0.3.2",
+                "lodash.isplainobject": "^4.0.4",
+                "lodash.isstring": "^4.0.1",
+                "lodash.mapvalues": "^4.4.0",
+                "rechoir": "^0.6.2",
+                "resolve": "^1.1.7"
             }
         },
         "lodash._basecopy": {
@@ -1932,7 +1932,7 @@
             "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
             "dev": true,
             "requires": {
-                "lodash._root": "3.0.1"
+                "lodash._root": "^3.0.0"
             }
         },
         "lodash.isarguments": {
@@ -1971,9 +1971,9 @@
             "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
             "dev": true,
             "requires": {
-                "lodash._getnative": "3.9.1",
-                "lodash.isarguments": "3.1.0",
-                "lodash.isarray": "3.0.4"
+                "lodash._getnative": "^3.0.0",
+                "lodash.isarguments": "^3.0.0",
+                "lodash.isarray": "^3.0.0"
             }
         },
         "lodash.mapvalues": {
@@ -1994,15 +1994,15 @@
             "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
             "dev": true,
             "requires": {
-                "lodash._basecopy": "3.0.1",
-                "lodash._basetostring": "3.0.1",
-                "lodash._basevalues": "3.0.0",
-                "lodash._isiterateecall": "3.0.9",
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0",
-                "lodash.keys": "3.1.2",
-                "lodash.restparam": "3.6.1",
-                "lodash.templatesettings": "3.1.1"
+                "lodash._basecopy": "^3.0.0",
+                "lodash._basetostring": "^3.0.0",
+                "lodash._basevalues": "^3.0.0",
+                "lodash._isiterateecall": "^3.0.0",
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0",
+                "lodash.keys": "^3.0.0",
+                "lodash.restparam": "^3.0.0",
+                "lodash.templatesettings": "^3.0.0"
             }
         },
         "lodash.templatesettings": {
@@ -2011,8 +2011,8 @@
             "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
             "dev": true,
             "requires": {
-                "lodash._reinterpolate": "3.0.0",
-                "lodash.escape": "3.2.0"
+                "lodash._reinterpolate": "^3.0.0",
+                "lodash.escape": "^3.0.0"
             }
         },
         "lru-cache": {
@@ -2039,7 +2039,7 @@
             "integrity": "sha1-QEEgLVCKNCugAXQAjfDCUbjBNeE=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.1"
             }
         },
         "micromatch": {
@@ -2048,19 +2048,19 @@
             "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
             "dev": true,
             "requires": {
-                "arr-diff": "2.0.0",
-                "array-unique": "0.2.1",
-                "braces": "1.8.5",
-                "expand-brackets": "0.1.5",
-                "extglob": "0.3.2",
-                "filename-regex": "2.0.1",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1",
-                "kind-of": "3.2.2",
-                "normalize-path": "2.1.1",
-                "object.omit": "2.0.1",
-                "parse-glob": "3.0.4",
-                "regex-cache": "0.4.3"
+                "arr-diff": "^2.0.0",
+                "array-unique": "^0.2.1",
+                "braces": "^1.8.2",
+                "expand-brackets": "^0.1.4",
+                "extglob": "^0.3.1",
+                "filename-regex": "^2.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.1",
+                "kind-of": "^3.0.2",
+                "normalize-path": "^2.0.1",
+                "object.omit": "^2.0.0",
+                "parse-glob": "^3.0.4",
+                "regex-cache": "^0.4.2"
             },
             "dependencies": {
                 "is-extglob": {
@@ -2075,7 +2075,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -2092,7 +2092,7 @@
             "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
             "dev": true,
             "requires": {
-                "mime-db": "1.30.0"
+                "mime-db": "~1.30.0"
             }
         },
         "minimatch": {
@@ -2101,8 +2101,8 @@
             "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
             "dev": true,
             "requires": {
-                "lru-cache": "2.7.3",
-                "sigmund": "1.0.1"
+                "lru-cache": "2",
+                "sigmund": "~1.0.0"
             }
         },
         "minimist": {
@@ -2150,10 +2150,10 @@
             "integrity": "sha1-nHkGoi+0wCkZ4vX3UWG0zb1LKis=",
             "dev": true,
             "requires": {
-                "array-differ": "1.0.0",
-                "array-union": "1.0.2",
-                "arrify": "1.0.1",
-                "minimatch": "3.0.4"
+                "array-differ": "^1.0.0",
+                "array-union": "^1.0.1",
+                "arrify": "^1.0.0",
+                "minimatch": "^3.0.0"
             },
             "dependencies": {
                 "minimatch": {
@@ -2162,7 +2162,7 @@
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.8"
+                        "brace-expansion": "^1.1.7"
                     }
                 }
             }
@@ -2194,7 +2194,7 @@
             "integrity": "sha1-p7iCyC1sk6SGOlUEvV3o7IYli5Y=",
             "dev": true,
             "requires": {
-                "is": "3.2.1"
+                "is": "^3.1.0"
             }
         },
         "normalize-path": {
@@ -2203,7 +2203,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.0.2"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "oauth-sign": {
@@ -2224,10 +2224,10 @@
             "integrity": "sha1-On+GgzS0B96gbaFtiNXNKeQ1/s8=",
             "dev": true,
             "requires": {
-                "array-each": "1.0.1",
-                "array-slice": "1.0.0",
-                "for-own": "1.0.0",
-                "isobject": "3.0.1"
+                "array-each": "^1.0.1",
+                "array-slice": "^1.0.0",
+                "for-own": "^1.0.0",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "for-own": {
@@ -2236,7 +2236,7 @@
                     "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
                     "dev": true,
                     "requires": {
-                        "for-in": "1.0.2"
+                        "for-in": "^1.0.1"
                     }
                 },
                 "isobject": {
@@ -2253,8 +2253,8 @@
             "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
             "dev": true,
             "requires": {
-                "for-own": "0.1.5",
-                "is-extendable": "0.1.1"
+                "for-own": "^0.1.4",
+                "is-extendable": "^0.1.1"
             }
         },
         "object.pick": {
@@ -2263,7 +2263,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "isobject": {
@@ -2280,7 +2280,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "orchestrator": {
@@ -2289,9 +2289,9 @@
             "integrity": "sha1-FOfp4nZPcxX7rBhOUGx6pt+UrX4=",
             "dev": true,
             "requires": {
-                "end-of-stream": "0.1.5",
-                "sequencify": "0.0.7",
-                "stream-consume": "0.1.0"
+                "end-of-stream": "~0.1.5",
+                "sequencify": "~0.0.7",
+                "stream-consume": "~0.1.0"
             },
             "dependencies": {
                 "end-of-stream": {
@@ -2300,7 +2300,7 @@
                     "integrity": "sha1-jhdyBsPICDfYVjLouTWd/osvbq8=",
                     "dev": true,
                     "requires": {
-                        "once": "1.3.3"
+                        "once": "~1.3.0"
                     }
                 },
                 "once": {
@@ -2309,7 +2309,7 @@
                     "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 }
             }
@@ -2320,8 +2320,8 @@
             "integrity": "sha1-cTfmmzKYuzQiR6G77jiByA4v14s=",
             "dev": true,
             "requires": {
-                "is-stream": "1.1.0",
-                "readable-stream": "2.3.3"
+                "is-stream": "^1.0.1",
+                "readable-stream": "^2.0.1"
             }
         },
         "os-homedir": {
@@ -2336,9 +2336,9 @@
             "integrity": "sha1-FZ1hVdQ5BNFsEO9piRHaHpGWm3M=",
             "dev": true,
             "requires": {
-                "is-absolute": "0.2.6",
-                "map-cache": "0.2.2",
-                "path-root": "0.1.1"
+                "is-absolute": "^0.2.3",
+                "map-cache": "^0.2.0",
+                "path-root": "^0.1.1"
             }
         },
         "parse-glob": {
@@ -2347,10 +2347,10 @@
             "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
             "dev": true,
             "requires": {
-                "glob-base": "0.3.0",
-                "is-dotfile": "1.0.3",
-                "is-extglob": "1.0.0",
-                "is-glob": "2.0.1"
+                "glob-base": "^0.3.0",
+                "is-dotfile": "^1.0.0",
+                "is-extglob": "^1.0.0",
+                "is-glob": "^2.0.0"
             },
             "dependencies": {
                 "is-extglob": {
@@ -2365,7 +2365,7 @@
                     "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "1.0.0"
+                        "is-extglob": "^1.0.0"
                     }
                 }
             }
@@ -2406,7 +2406,7 @@
             "integrity": "sha1-mkpoFMrBwM1zNgqV8yCDyOpHRbc=",
             "dev": true,
             "requires": {
-                "path-root-regex": "0.1.2"
+                "path-root-regex": "^0.1.0"
             }
         },
         "path-root-regex": {
@@ -2421,7 +2421,7 @@
             "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "~2.3"
             }
         },
         "pend": {
@@ -2442,7 +2442,7 @@
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
             "dev": true,
             "requires": {
-                "pinkie": "2.0.4"
+                "pinkie": "^2.0.0"
             }
         },
         "preserve": {
@@ -2487,7 +2487,7 @@
             "integrity": "sha1-bEnQHwCeIlZ4h4nyv/rGuLmZBYU=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3"
+                "inherits": "~2.0.0"
             }
         },
         "randomatic": {
@@ -2496,8 +2496,8 @@
             "integrity": "sha1-x6vpzIuHwLqodrGf3oP9RkeX44w=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -2506,7 +2506,7 @@
                     "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
                     "dev": true,
                     "requires": {
-                        "kind-of": "3.2.2"
+                        "kind-of": "^3.0.2"
                     },
                     "dependencies": {
                         "kind-of": {
@@ -2515,7 +2515,7 @@
                             "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                             "dev": true,
                             "requires": {
-                                "is-buffer": "1.1.5"
+                                "is-buffer": "^1.1.5"
                             }
                         }
                     }
@@ -2526,7 +2526,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.5"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -2537,13 +2537,13 @@
             "integrity": "sha1-No8lEtefnUb9/HE0mueHi7weuVw=",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.0.3",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.0.3",
+                "util-deprecate": "~1.0.1"
             }
         },
         "rechoir": {
@@ -2552,7 +2552,7 @@
             "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
             "dev": true,
             "requires": {
-                "resolve": "1.4.0"
+                "resolve": "^1.1.6"
             }
         },
         "regex-cache": {
@@ -2561,8 +2561,8 @@
             "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
             "dev": true,
             "requires": {
-                "is-equal-shallow": "0.1.3",
-                "is-primitive": "2.0.0"
+                "is-equal-shallow": "^0.1.3",
+                "is-primitive": "^2.0.0"
             }
         },
         "remove-trailing-separator": {
@@ -2601,7 +2601,7 @@
             "integrity": "sha1-p1vgHFPaJdk0qY69DkxKcxL5KoY=",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.5"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-dir": {
@@ -2610,8 +2610,8 @@
             "integrity": "sha1-shklmlYC+sXFxJatiUpujMQwJh4=",
             "dev": true,
             "requires": {
-                "expand-tilde": "1.2.2",
-                "global-modules": "0.2.3"
+                "expand-tilde": "^1.2.2",
+                "global-modules": "^0.2.3"
             }
         },
         "rimraf": {
@@ -2620,7 +2620,7 @@
             "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2"
+                "glob": "^7.0.5"
             },
             "dependencies": {
                 "glob": {
@@ -2672,7 +2672,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -2687,9 +2687,9 @@
             "integrity": "sha512-pRXeNrCA2Wd9itwhvLp5LZQvPJ0wU6bcjaTMywHHGX5XWhVN2nzSu7WV0q+oUY7mGK3mgSkDDzP3MgjqdyIgbQ==",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "interpret": "1.0.3",
-                "rechoir": "0.6.2"
+                "glob": "^7.0.0",
+                "interpret": "^1.0.0",
+                "rechoir": "^0.6.2"
             },
             "dependencies": {
                 "glob": {
@@ -2698,12 +2698,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "minimatch": {
@@ -2712,7 +2712,7 @@
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.8"
+                        "brace-expansion": "^1.1.7"
                     }
                 }
             }
@@ -2729,7 +2729,7 @@
             "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
             "dev": true,
             "requires": {
-                "hoek": "2.16.3"
+                "hoek": "2.x.x"
             }
         },
         "sparkles": {
@@ -2744,7 +2744,7 @@
             "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
             "dev": true,
             "requires": {
-                "through": "2.3.8"
+                "through": "2"
             }
         },
         "sshpk": {
@@ -2753,14 +2753,14 @@
             "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
             "dev": true,
             "requires": {
-                "asn1": "0.2.3",
-                "assert-plus": "1.0.0",
-                "bcrypt-pbkdf": "1.0.1",
-                "dashdash": "1.14.1",
-                "ecc-jsbn": "0.1.1",
-                "getpass": "0.1.7",
-                "jsbn": "0.1.1",
-                "tweetnacl": "0.14.5"
+                "asn1": "~0.2.3",
+                "assert-plus": "^1.0.0",
+                "bcrypt-pbkdf": "^1.0.0",
+                "dashdash": "^1.12.0",
+                "ecc-jsbn": "~0.1.1",
+                "getpass": "^0.1.1",
+                "jsbn": "~0.1.0",
+                "tweetnacl": "~0.14.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -2783,7 +2783,7 @@
             "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
             "dev": true,
             "requires": {
-                "duplexer": "0.1.1"
+                "duplexer": "~0.1.1"
             }
         },
         "stream-consume": {
@@ -2804,7 +2804,7 @@
             "integrity": "sha1-h1BxEb644phFFxe1Ec/tjwAqv1M=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3"
+                "readable-stream": "^2.0.2"
             }
         },
         "streamifier": {
@@ -2819,7 +2819,7 @@
             "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "~5.1.0"
             }
         },
         "stringstream": {
@@ -2834,7 +2834,7 @@
             "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "2.1.1"
+                "ansi-regex": "^2.0.0"
             }
         },
         "strip-bom": {
@@ -2843,7 +2843,7 @@
             "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
             "dev": true,
             "requires": {
-                "is-utf8": "0.2.1"
+                "is-utf8": "^0.2.0"
             }
         },
         "strip-bom-stream": {
@@ -2852,8 +2852,8 @@
             "integrity": "sha1-5xRDmFd9Uaa+0PoZlPoF9D/ZiO4=",
             "dev": true,
             "requires": {
-                "first-chunk-stream": "1.0.0",
-                "strip-bom": "2.0.0"
+                "first-chunk-stream": "^1.0.0",
+                "strip-bom": "^2.0.0"
             }
         },
         "supports-color": {
@@ -2868,9 +2868,9 @@
             "integrity": "sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=",
             "dev": true,
             "requires": {
-                "block-stream": "0.0.9",
-                "fstream": "1.0.11",
-                "inherits": "2.0.3"
+                "block-stream": "*",
+                "fstream": "^1.0.2",
+                "inherits": "2"
             }
         },
         "through": {
@@ -2885,8 +2885,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.3",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "through2-filter": {
@@ -2895,8 +2895,8 @@
             "integrity": "sha1-YLxVoNrLdghdsfna6Zq0P4PWIuw=",
             "dev": true,
             "requires": {
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "through2": "~2.0.0",
+                "xtend": "~4.0.0"
             }
         },
         "tildify": {
@@ -2905,7 +2905,7 @@
             "integrity": "sha1-3OwD9V3Km3qj5bBPIYF+tW5jWIo=",
             "dev": true,
             "requires": {
-                "os-homedir": "1.0.2"
+                "os-homedir": "^1.0.0"
             }
         },
         "time-stamp": {
@@ -2920,7 +2920,7 @@
             "integrity": "sha1-HN+kcqnvUMI57maZm2YsoOs5k38=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1"
+                "extend-shallow": "^2.0.1"
             }
         },
         "to-iso-string": {
@@ -2935,7 +2935,7 @@
             "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
             "dev": true,
             "requires": {
-                "punycode": "1.4.1"
+                "punycode": "^1.4.1"
             }
         },
         "tslib": {
@@ -2950,16 +2950,16 @@
             "integrity": "sha1-wl4NDJL6EgHCvDDoROCOaCtPNVI=",
             "dev": true,
             "requires": {
-                "babel-code-frame": "6.26.0",
-                "colors": "1.1.2",
-                "commander": "2.11.0",
-                "diff": "3.3.1",
-                "glob": "7.1.2",
-                "minimatch": "3.0.4",
-                "resolve": "1.4.0",
-                "semver": "5.4.1",
-                "tslib": "1.7.1",
-                "tsutils": "2.8.2"
+                "babel-code-frame": "^6.22.0",
+                "colors": "^1.1.2",
+                "commander": "^2.9.0",
+                "diff": "^3.2.0",
+                "glob": "^7.1.1",
+                "minimatch": "^3.0.4",
+                "resolve": "^1.3.2",
+                "semver": "^5.3.0",
+                "tslib": "^1.7.1",
+                "tsutils": "^2.8.1"
             },
             "dependencies": {
                 "commander": {
@@ -2980,12 +2980,12 @@
                     "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
                     "dev": true,
                     "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "minimatch": {
@@ -2994,7 +2994,7 @@
                     "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.8"
+                        "brace-expansion": "^1.1.7"
                     }
                 }
             }
@@ -3005,7 +3005,7 @@
             "integrity": "sha1-LBSGukMSYIRbCsb5Aq/Z1wio6mo=",
             "dev": true,
             "requires": {
-                "tslib": "1.7.1"
+                "tslib": "^1.7.1"
             }
         },
         "tunnel-agent": {
@@ -3039,8 +3039,8 @@
             "integrity": "sha1-WqADz76Uxf+GbE59ZouxxNuts2k=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "1.0.1",
-                "through2-filter": "2.0.0"
+                "json-stable-stringify": "^1.0.0",
+                "through2-filter": "^2.0.0"
             }
         },
         "url-parse": {
@@ -3049,8 +3049,8 @@
             "integrity": "sha1-xn8dd11R8KGJEd17P/rSe7nlvRk=",
             "dev": true,
             "requires": {
-                "querystringify": "1.0.0",
-                "requires-port": "1.0.0"
+                "querystringify": "~1.0.0",
+                "requires-port": "1.0.x"
             }
         },
         "user-home": {
@@ -3077,7 +3077,7 @@
             "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
             "dev": true,
             "requires": {
-                "user-home": "1.1.1"
+                "user-home": "^1.1.1"
             }
         },
         "vali-date": {
@@ -3092,9 +3092,9 @@
             "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
             "dev": true,
             "requires": {
-                "assert-plus": "1.0.0",
+                "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
-                "extsprintf": "1.3.0"
+                "extsprintf": "^1.2.0"
             },
             "dependencies": {
                 "assert-plus": {
@@ -3111,8 +3111,8 @@
             "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
             "dev": true,
             "requires": {
-                "clone": "1.0.2",
-                "clone-stats": "0.0.1",
+                "clone": "^1.0.0",
+                "clone-stats": "^0.0.1",
                 "replace-ext": "0.0.1"
             }
         },
@@ -3122,23 +3122,23 @@
             "integrity": "sha1-vm/zJwy1Xf19MGNkDegfJddTIjk=",
             "dev": true,
             "requires": {
-                "duplexify": "3.5.1",
-                "glob-stream": "5.3.5",
-                "graceful-fs": "4.1.11",
+                "duplexify": "^3.2.0",
+                "glob-stream": "^5.3.2",
+                "graceful-fs": "^4.0.0",
                 "gulp-sourcemaps": "1.6.0",
-                "is-valid-glob": "0.3.0",
-                "lazystream": "1.0.0",
-                "lodash.isequal": "4.5.0",
-                "merge-stream": "1.0.1",
-                "mkdirp": "0.5.1",
-                "object-assign": "4.1.1",
-                "readable-stream": "2.3.3",
-                "strip-bom": "2.0.0",
-                "strip-bom-stream": "1.0.0",
-                "through2": "2.0.3",
-                "through2-filter": "2.0.0",
-                "vali-date": "1.0.0",
-                "vinyl": "1.2.0"
+                "is-valid-glob": "^0.3.0",
+                "lazystream": "^1.0.0",
+                "lodash.isequal": "^4.0.0",
+                "merge-stream": "^1.0.0",
+                "mkdirp": "^0.5.0",
+                "object-assign": "^4.0.0",
+                "readable-stream": "^2.0.4",
+                "strip-bom": "^2.0.0",
+                "strip-bom-stream": "^1.0.0",
+                "through2": "^2.0.0",
+                "through2-filter": "^2.0.0",
+                "vali-date": "^1.0.0",
+                "vinyl": "^1.0.0"
             },
             "dependencies": {
                 "object-assign": {
@@ -3153,8 +3153,8 @@
                     "integrity": "sha1-XIgDbPVl5d8FVYv8kR+GVt8hiIQ=",
                     "dev": true,
                     "requires": {
-                        "clone": "1.0.2",
-                        "clone-stats": "0.0.1",
+                        "clone": "^1.0.0",
+                        "clone-stats": "^0.0.1",
                         "replace-ext": "0.0.1"
                     }
                 }
@@ -3166,8 +3166,8 @@
             "integrity": "sha1-RMvlEIIFJ53rDFZTwJSiiHk4sas=",
             "dev": true,
             "requires": {
-                "through2": "0.6.5",
-                "vinyl": "0.4.6"
+                "through2": "^0.6.1",
+                "vinyl": "^0.4.3"
             },
             "dependencies": {
                 "clone": {
@@ -3188,10 +3188,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "string_decoder": {
@@ -3206,8 +3206,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 },
                 "vinyl": {
@@ -3228,20 +3228,20 @@
             "integrity": "sha1-Ru0a+iwbnWifY5TI8WvR1xkPdfs=",
             "dev": true,
             "requires": {
-                "glob": "7.1.2",
-                "gulp-chmod": "2.0.0",
-                "gulp-filter": "5.0.1",
+                "glob": "^7.1.2",
+                "gulp-chmod": "^2.0.0",
+                "gulp-filter": "^5.0.1",
                 "gulp-gunzip": "1.0.0",
-                "gulp-remote-src": "0.4.3",
-                "gulp-symdest": "1.1.0",
-                "gulp-untar": "0.0.6",
-                "gulp-vinyl-zip": "2.1.0",
-                "mocha": "4.0.1",
-                "request": "2.83.0",
-                "semver": "5.4.1",
-                "source-map-support": "0.5.0",
-                "url-parse": "1.1.9",
-                "vinyl-source-stream": "1.1.0"
+                "gulp-remote-src": "^0.4.3",
+                "gulp-symdest": "^1.1.0",
+                "gulp-untar": "^0.0.6",
+                "gulp-vinyl-zip": "^2.1.0",
+                "mocha": "^4.0.1",
+                "request": "^2.83.0",
+                "semver": "^5.4.1",
+                "source-map-support": "^0.5.0",
+                "url-parse": "^1.1.9",
+                "vinyl-source-stream": "^1.1.0"
             },
             "dependencies": {
                 "ajv": {
@@ -3250,10 +3250,10 @@
                     "integrity": "sha1-Pa+ai2ciEpn9ro2C0RftjmyAJEs=",
                     "dev": true,
                     "requires": {
-                        "co": "4.6.0",
-                        "fast-deep-equal": "1.0.0",
-                        "json-schema-traverse": "0.3.1",
-                        "json-stable-stringify": "1.0.1"
+                        "co": "^4.6.0",
+                        "fast-deep-equal": "^1.0.0",
+                        "json-schema-traverse": "^0.3.0",
+                        "json-stable-stringify": "^1.0.1"
                     }
                 },
                 "assert-plus": {
@@ -3274,7 +3274,7 @@
                     "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
                     "dev": true,
                     "requires": {
-                        "hoek": "4.2.0"
+                        "hoek": "4.x.x"
                     }
                 },
                 "caseless": {
@@ -3301,7 +3301,7 @@
                     "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
                     "dev": true,
                     "requires": {
-                        "boom": "5.2.0"
+                        "boom": "5.x.x"
                     },
                     "dependencies": {
                         "boom": {
@@ -3310,7 +3310,7 @@
                             "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
                             "dev": true,
                             "requires": {
-                                "hoek": "4.2.0"
+                                "hoek": "4.x.x"
                             }
                         }
                     }
@@ -3342,9 +3342,9 @@
                     "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
                     "dev": true,
                     "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.17"
+                        "asynckit": "^0.4.0",
+                        "combined-stream": "^1.0.5",
+                        "mime-types": "^2.1.12"
                     }
                 },
                 "glob": {
@@ -3373,8 +3373,8 @@
                     "integrity": "sha1-FbdBFF6Dqcb1CIYkG1fMWHHxUak=",
                     "dev": true,
                     "requires": {
-                        "through2": "0.6.5",
-                        "vinyl": "0.4.6"
+                        "through2": "~0.6.5",
+                        "vinyl": "~0.4.6"
                     }
                 },
                 "gulp-vinyl-zip": {
@@ -3383,13 +3383,13 @@
                     "integrity": "sha1-JOQGhdwFtxSZlSRQmeBZAmO+ja0=",
                     "dev": true,
                     "requires": {
-                        "event-stream": "3.3.4",
-                        "queue": "4.4.1",
-                        "through2": "2.0.3",
-                        "vinyl": "2.1.0",
-                        "vinyl-fs": "2.4.4",
-                        "yauzl": "2.8.0",
-                        "yazl": "2.4.2"
+                        "event-stream": "^3.3.1",
+                        "queue": "^4.2.1",
+                        "through2": "^2.0.3",
+                        "vinyl": "^2.0.2",
+                        "vinyl-fs": "^2.0.0",
+                        "yauzl": "^2.2.1",
+                        "yazl": "^2.2.1"
                     },
                     "dependencies": {
                         "clone": {
@@ -3416,13 +3416,13 @@
                             "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
                             "dev": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
-                                "isarray": "1.0.0",
-                                "process-nextick-args": "1.0.7",
-                                "safe-buffer": "5.1.1",
-                                "string_decoder": "1.0.3",
-                                "util-deprecate": "1.0.2"
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.3",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~1.0.6",
+                                "safe-buffer": "~5.1.1",
+                                "string_decoder": "~1.0.3",
+                                "util-deprecate": "~1.0.1"
                             }
                         },
                         "string_decoder": {
@@ -3431,7 +3431,7 @@
                             "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
                             "dev": true,
                             "requires": {
-                                "safe-buffer": "5.1.1"
+                                "safe-buffer": "~5.1.0"
                             }
                         },
                         "through2": {
@@ -3440,8 +3440,8 @@
                             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
                             "dev": true,
                             "requires": {
-                                "readable-stream": "2.3.3",
-                                "xtend": "4.0.1"
+                                "readable-stream": "^2.1.5",
+                                "xtend": "~4.0.1"
                             }
                         },
                         "vinyl": {
@@ -3450,12 +3450,12 @@
                             "integrity": "sha1-Ah+cLPlR1rk5lDyJ617lrdT9kkw=",
                             "dev": true,
                             "requires": {
-                                "clone": "2.1.1",
-                                "clone-buffer": "1.0.0",
-                                "clone-stats": "1.0.0",
-                                "cloneable-readable": "1.0.0",
-                                "remove-trailing-separator": "1.0.2",
-                                "replace-ext": "1.0.0"
+                                "clone": "^2.1.1",
+                                "clone-buffer": "^1.0.0",
+                                "clone-stats": "^1.0.0",
+                                "cloneable-readable": "^1.0.0",
+                                "remove-trailing-separator": "^1.0.1",
+                                "replace-ext": "^1.0.0"
                             }
                         }
                     }
@@ -3472,8 +3472,8 @@
                     "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
                     "dev": true,
                     "requires": {
-                        "ajv": "5.2.4",
-                        "har-schema": "2.0.0"
+                        "ajv": "^5.1.0",
+                        "har-schema": "^2.0.0"
                     }
                 },
                 "has-flag": {
@@ -3488,10 +3488,10 @@
                     "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
                     "dev": true,
                     "requires": {
-                        "boom": "4.3.1",
-                        "cryptiles": "3.1.2",
-                        "hoek": "4.2.0",
-                        "sntp": "2.0.2"
+                        "boom": "4.x.x",
+                        "cryptiles": "3.x.x",
+                        "hoek": "4.x.x",
+                        "sntp": "2.x.x"
                     }
                 },
                 "hoek": {
@@ -3506,9 +3506,9 @@
                     "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
                     "dev": true,
                     "requires": {
-                        "assert-plus": "1.0.0",
-                        "jsprim": "1.4.1",
-                        "sshpk": "1.13.1"
+                        "assert-plus": "^1.0.0",
+                        "jsprim": "^1.2.2",
+                        "sshpk": "^1.7.0"
                     }
                 },
                 "isarray": {
@@ -3568,7 +3568,7 @@
                     "integrity": "sha512-Lcs97MDk4ewesYBtC6P3hl+klvVmHN2PLzgsQcK29bVQ2+5T0Ef0ZmXhBIINkpJd3LzZK29MWjyTL2lGLYGOPA==",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3"
+                        "inherits": "~2.0.0"
                     }
                 },
                 "readable-stream": {
@@ -3577,10 +3577,10 @@
                     "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
                     "dev": true,
                     "requires": {
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.1",
                         "isarray": "0.0.1",
-                        "string_decoder": "0.10.31"
+                        "string_decoder": "~0.10.x"
                     }
                 },
                 "replace-ext": {
@@ -3595,28 +3595,28 @@
                     "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
                     "dev": true,
                     "requires": {
-                        "aws-sign2": "0.7.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.3.1",
-                        "har-validator": "5.0.3",
-                        "hawk": "6.0.2",
-                        "http-signature": "1.2.0",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.17",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "2.1.0",
-                        "qs": "6.5.1",
-                        "safe-buffer": "5.1.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.3",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.1.0"
+                        "aws-sign2": "~0.7.0",
+                        "aws4": "^1.6.0",
+                        "caseless": "~0.12.0",
+                        "combined-stream": "~1.0.5",
+                        "extend": "~3.0.1",
+                        "forever-agent": "~0.6.1",
+                        "form-data": "~2.3.1",
+                        "har-validator": "~5.0.3",
+                        "hawk": "~6.0.2",
+                        "http-signature": "~1.2.0",
+                        "is-typedarray": "~1.0.0",
+                        "isstream": "~0.1.2",
+                        "json-stringify-safe": "~5.0.1",
+                        "mime-types": "~2.1.17",
+                        "oauth-sign": "~0.8.2",
+                        "performance-now": "^2.1.0",
+                        "qs": "~6.5.1",
+                        "safe-buffer": "^5.1.1",
+                        "stringstream": "~0.0.5",
+                        "tough-cookie": "~2.3.3",
+                        "tunnel-agent": "^0.6.0",
+                        "uuid": "^3.1.0"
                     }
                 },
                 "sntp": {
@@ -3625,7 +3625,7 @@
                     "integrity": "sha1-UGQRDwr4X3z9t9a2ekACjOUrSys=",
                     "dev": true,
                     "requires": {
-                        "hoek": "4.2.0"
+                        "hoek": "4.x.x"
                     }
                 },
                 "source-map": {
@@ -3640,7 +3640,7 @@
                     "integrity": "sha512-vUoN3I7fHQe0R/SJLKRdKYuEdRGogsviXFkHHo17AWaTGv17VLnxw+CFXvqy+y4ORZ3doWLQcxRYfwKrsd/H7Q==",
                     "dev": true,
                     "requires": {
-                        "source-map": "0.6.1"
+                        "source-map": "^0.6.0"
                     }
                 },
                 "string_decoder": {
@@ -3664,8 +3664,8 @@
                     "integrity": "sha1-QaucZ7KdVyCQcUEOHXp6lozTrUg=",
                     "dev": true,
                     "requires": {
-                        "readable-stream": "1.0.34",
-                        "xtend": "4.0.1"
+                        "readable-stream": ">=1.0.33-1 <1.1.0-0",
+                        "xtend": ">=4.0.0 <4.1.0-0"
                     }
                 },
                 "tough-cookie": {
@@ -3674,7 +3674,7 @@
                     "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
                     "dev": true,
                     "requires": {
-                        "punycode": "1.4.1"
+                        "punycode": "^1.4.1"
                     }
                 },
                 "tunnel-agent": {
@@ -3683,7 +3683,7 @@
                     "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "^5.0.1"
                     }
                 },
                 "vinyl": {
@@ -3692,8 +3692,8 @@
                     "integrity": "sha1-LzVsh6VQolVGHza76ypbqL94SEc=",
                     "dev": true,
                     "requires": {
-                        "clone": "0.2.0",
-                        "clone-stats": "0.0.1"
+                        "clone": "^0.2.0",
+                        "clone-stats": "^0.0.1"
                     }
                 }
             }
@@ -3713,7 +3713,7 @@
             "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "winreg": {
@@ -3739,8 +3739,8 @@
             "integrity": "sha1-eUUK/yKyqcWkHvVOAtuQfM+/nuI=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13",
-                "fd-slicer": "1.0.1"
+                "buffer-crc32": "~0.2.3",
+                "fd-slicer": "~1.0.1"
             }
         },
         "yazl": {
@@ -3749,7 +3749,7 @@
             "integrity": "sha1-FMsZCD4eJacAksFYiqvg9OTdTYg=",
             "dev": true,
             "requires": {
-                "buffer-crc32": "0.2.13"
+                "buffer-crc32": "~0.2.3"
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,9 @@
       {
         "type": "java",
         "label": "Java",
+        "languages": [
+          "java"
+        ],
         "enableBreakpointsFor": {
           "languageIds": [
             "java"


### PR DESCRIPTION
Now for single file debugging:
![single](https://user-images.githubusercontent.com/2351748/42495706-6d537db6-8456-11e8-8cb6-a5785b9ac6d3.gif)

Actually it also fixes the issue for other java projects. E.g. previously for a newly opened Springboot project, we have to press <F5> and select "Java" first to create a `launch.json` file.