### PR TITLE
Robustness: judge no launch.json exists.

### DIFF
--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -101,11 +101,11 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
              * If no launch.json exists in the current workspace folder
              * delegate to provideDebugConfigurations api to generate the initial launch.json configurations
              */
-            if (!config.request && folder !== undefined) {
+            if (this.isEmptyConfig(config) && folder !== undefined) {
                 return config;
             }
             // If it's the single file case that no workspace folder is opened, generate debug config in memory
-            if (!config.request && !folder) {
+            if (this.isEmptyConfig(config) && !folder) {
                 config.type = "java";
                 config.name = "Java Debug";
                 config.request = "launch";
@@ -201,6 +201,11 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
 
     private isEmptyArray(configItems: any): boolean {
         return !Array.isArray(configItems) || !configItems.length;
+    }
+
+    private isEmptyConfig(config: vscode.DebugConfiguration): boolean {
+        // filter out the auto filled field "noDebug"
+        return Object.keys(config).filter((key: string) => key !== "noDebug").length === 0;
     }
 
     private async chooseMainClass(folder: vscode.WorkspaceFolder | undefined): Promise<IMainClassOption | undefined> {

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -101,11 +101,11 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
              * If no launch.json exists in the current workspace folder
              * delegate to provideDebugConfigurations api to generate the initial launch.json configurations
              */
-            if (Object.keys(config).length === 0 && folder !== undefined) {
+            if (!config.request && folder !== undefined) {
                 return config;
             }
             // If it's the single file case that no workspace folder is opened, generate debug config in memory
-            if (Object.keys(config).length === 0 && !folder) {
+            if (!config.request && !folder) {
                 config.type = "java";
                 config.name = "Java Debug";
                 config.request = "launch";

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -101,11 +101,11 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
              * If no launch.json exists in the current workspace folder
              * delegate to provideDebugConfigurations api to generate the initial launch.json configurations
              */
-            if (this.isEmptyConfig(config) && folder !== undefined) {
+            if (this.isValidConfig(config) && folder !== undefined) {
                 return config;
             }
             // If it's the single file case that no workspace folder is opened, generate debug config in memory
-            if (this.isEmptyConfig(config) && !folder) {
+            if (this.isValidConfig(config) && !folder) {
                 config.type = "java";
                 config.name = "Java Debug";
                 config.request = "launch";

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -203,7 +203,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
         return !Array.isArray(configItems) || !configItems.length;
     }
 
-    private isEmptyConfig(config: vscode.DebugConfiguration): boolean {
+    private isValidConfig(config: vscode.DebugConfiguration): boolean {
         // filter out the auto filled field "noDebug"
         return Object.keys(config).filter((key: string) => key !== "noDebug").length === 0;
     }

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -103,11 +103,11 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
              * If no launch.json exists in the current workspace folder
              * delegate to provideDebugConfigurations api to generate the initial launch.json configurations
              */
-            if (this.isValidConfig(config) && folder !== undefined) {
+            if (this.isEmptyConfig(config) && folder !== undefined) {
                 return config;
             }
             // If it's the single file case that no workspace folder is opened, generate debug config in memory
-            if (this.isValidConfig(config) && !folder) {
+            if (this.isEmptyConfig(config) && !folder) {
                 config.type = "java";
                 config.name = "Java Debug";
                 config.request = "launch";
@@ -205,8 +205,11 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
         return !Array.isArray(configItems) || !configItems.length;
     }
 
-    private isValidConfig(config: vscode.DebugConfiguration): boolean {
-        // filter out the auto filled field "noDebug"
+    /**
+     * When VS Code cannot find any available DebugConfiguration, it passes a { noDebug?: boolean } to resolve.
+     * This function judges whether a DebugConfiguration is empty by filtering out the field "noDebug".
+     */
+    private isEmptyConfig(config: vscode.DebugConfiguration): boolean {
         return Object.keys(config).filter((key: string) => key !== "noDebug").length === 0;
     }
 


### PR DESCRIPTION
Pressing <kbd>Ctrl+F5</kbd> for a single file / first-time-opened project, the initial config to resolve is `{ noDebug: true }`. 
Current conditional doesn't apply. 

See more in  https://github.com/Microsoft/vscode-java-debug/issues/376#issuecomment-415677697
