### PR TITLE
Ignore auto-generated files in test projects.

### DIFF
--- a/testprojects/12.gradle/.gitignore
+++ b/testprojects/12.gradle/.gitignore
@@ -1,0 +1,6 @@
+# Language server somehow recognizes build.gradle and compile this project.
+# Ignore following generated files to keep SCM clean.
+.gradle/
+.settings/
+.project
+.classpath


### PR DESCRIPTION
When developing the extension, the language server somehow is activated and recognizes the gradle projects. It auto generates some files. It's better to ignore them in case of being mistakenly checked in.