### PR TITLE
Change active editor oct icon to file-text instead of clock

### DIFF
--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -382,7 +382,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
             if (pickItems[positionForActiveEditor].detail) {
                 pickItems[positionForActiveEditor].detail += `, active editor (${path.basename(options[positionForActiveEditor].filePath)})`;
             } else {
-                pickItems[positionForActiveEditor].detail = `$(clock) active editor (${path.basename(options[positionForActiveEditor].filePath)})`;
+                pickItems[positionForActiveEditor].detail = `$(file-text) active editor (${path.basename(options[positionForActiveEditor].filePath)})`;
             }
         }
 


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fix issue https://github.com/Microsoft/vscode-java-debug/issues/403
