### PR TITLE
resolveDebugConfiguration returns null to tell vscode to continue generating launch.json

### DIFF
--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -136,7 +136,9 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
              * delegate to provideDebugConfigurations api to generate the initial launch.json configurations
              */
             if (this.isEmptyConfig(config) && folder !== undefined) {
-                return config;
+                // Follow the feature request https://github.com/Microsoft/vscode/issues/54213#issuecomment-420965778,
+                // in order to generate launch.json, the resolveDebugConfiguration api must return null explicitly.
+                return null;
             }
             // If it's the single file case that no workspace folder is opened, generate debug config in memory
             if (this.isEmptyConfig(config) && !folder) {


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Follow the issue https://github.com/Microsoft/vscode/issues/54213#issuecomment-420965778, in order to generate launch.json, the resolveDebugConfiguration api must return null explicitly.

This change doesn't affect current vscode behavior, but also prevent the future break change from the vscode insider. So i prefer to change vscode java debug source code in advance.