### PR TITLE
Use the java_home info exposed by vscode-java to launch debuggee program

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1572,11 +1572,6 @@
                 "is-posix-bracket": "0.1.1"
             }
         },
-        "expand-home-dir": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/expand-home-dir/-/expand-home-dir-0.0.3.tgz",
-            "integrity": "sha1-ct6KBIbMKKO71wRjU5iCW1tign0="
-        },
         "expand-range": {
             "version": "1.8.2",
             "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
@@ -1681,22 +1676,6 @@
                 "randomatic": "3.1.0",
                 "repeat-element": "1.1.2",
                 "repeat-string": "1.6.1"
-            }
-        },
-        "find-java-home": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/find-java-home/-/find-java-home-0.2.0.tgz",
-            "integrity": "sha512-nq5PFOHxE1VSEbdDVkLoA2bAcRnG4ETqJO8ipFq3glIWA52hdWCXYX3emuUyMAQfaqFU4Ea85gqcgaPmOApEPA==",
-            "requires": {
-                "which": "1.0.9",
-                "winreg": "1.2.4"
-            },
-            "dependencies": {
-                "which": {
-                    "version": "1.0.9",
-                    "resolved": "https://registry.npmjs.org/which/-/which-1.0.9.tgz",
-                    "integrity": "sha1-RgwdoPgQED0DIam2M6+eV15kSG8="
-                }
             }
         },
         "find-up": {
@@ -5028,11 +5007,6 @@
             "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
             "dev": true
         },
-        "path-exists": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-            "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
-        },
         "path-is-absolute": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
@@ -6713,11 +6687,6 @@
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
             "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
             "dev": true
-        },
-        "winreg": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/winreg/-/winreg-1.2.4.tgz",
-            "integrity": "sha1-ugZWKbepJRMOFXeRCM9UCZDpjRs="
         },
         "wrap-ansi": {
             "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -391,11 +391,8 @@
     "vscode": "^1.1.21"
   },
   "dependencies": {
-    "expand-home-dir": "0.0.3",
-    "find-java-home": "^0.2.0",
     "lodash": "^4.17.10",
     "opn": "^5.3.0",
-    "path-exists": "^3.0.0",
     "vscode-extension-telemetry": "0.0.18",
     "vscode-extension-telemetry-wrapper": "^0.3.1"
   }

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,11 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as expandHomeDir from "expand-home-dir";
-import * as findJavaHome from "find-java-home";
 import * as opn from "opn";
-import * as path from "path";
-import * as pathExists from "path-exists";
 import * as vscode from "vscode";
 import { logger, Type } from "./logger";
 
@@ -114,24 +110,15 @@ export function formatErrorProperties(ex: any): IProperties {
     return properties;
 }
 
-export function getJavaHome(): Promise<string> {
-    const EXE_SUFFIX = process.platform.startsWith("win") ? ".exe" : "";
-    return new Promise((resolve, reject) => {
-        let javaHome: string = readJavaConfig() || process.env.JDK_HOME || process.env.JAVA_HOME;
-        if (javaHome) {
-            javaHome = expandHomeDir(javaHome);
-            if (pathExists.sync(javaHome) && pathExists.sync(path.resolve(javaHome, "bin", `javac${EXE_SUFFIX}`))) {
-                return resolve(javaHome);
-            }
+export async function getJavaHome(): Promise<string> {
+    const extension = vscode.extensions.getExtension("redhat.java");
+    try {
+        const extensionApi = await extension.activate();
+        if (extensionApi && extensionApi.javaRequirement) {
+            return extensionApi.javaRequirement.java_home;
         }
+    } catch (ex) {
+    }
 
-        findJavaHome((err, home) => {
-            resolve(err ? "" : expandHomeDir(home));
-        });
-    });
-}
-
-function readJavaConfig(): string {
-    const config = vscode.workspace.getConfiguration();
-    return config.get<string>("java.home", null);
+    return "";
 }


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Refer to issue https://github.com/redhat-developer/vscode-java/issues/639, vscode-java will expose the resolve java_home at the extension return value.  Other extensions can get the value via vscode extension api.