### PR TITLE
Add way to disable run and debug code lens provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Please also check the documentation of [Language Support for Java by Red Hat](ht
 - `java.debug.settings.showQualifiedNames`: show fully qualified class names in "Variables" viewlet, defaults to `false`.
 - `java.debug.settings.maxStringLength`: the maximum length of string displayed in "Variables" or "Debug Console" viewlet, the string longer than this length will be trimmed, defaults to `0` which means no trim is performed.
 - `java.debug.settings.enableHotCodeReplace`: enable hot code replace for Java code. Make sure the auto build is not disabled for [VSCode Java](https://github.com/redhat-developer/vscode-java). See the [wiki page](https://github.com/Microsoft/vscode-java-debug/wiki/Hot-Code-Replace) for more information about usages and limitations.
+- `java.debug.settings.enableRunDebugCodeLens`: enable the code lens provider for the run and debug buttons over main entry points, defaults to `true`.
 
 ## Troubleshooting
 Reference the [troubleshooting guide](https://github.com/Microsoft/vscode-java-debug/blob/master/Troubleshooting.md) for common errors.

--- a/package.json
+++ b/package.json
@@ -367,7 +367,7 @@
         },
         "java.debug.settings.enableRunDebugCodeLens": {
           "type": "boolean",
-          "description": "Enable the run and debug code lens providers over main methods",
+          "description": "%java.debugger.configuration.enableRunDebugCodeLens.description%",
           "default": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -364,6 +364,11 @@
           "type": "boolean",
           "description": "Enable hot code replace for Java code",
           "default": true
+        },
+        "java.debug.settings.enableRunDebugCodeLens": {
+          "type": "boolean",
+          "description": "Enable the run and debug code lens providers over main methods",
+          "default": true
         }
       }
     }

--- a/package.nls.it.json
+++ b/package.nls.it.json
@@ -6,5 +6,5 @@
     "java.debugger.configuration.showQualifiedNames.description": "Mostra nome completo delle classi nella scheda \"variabili\".",
     "java.debugger.configuration.maxStringLength.description": "Lunghezza massima delle stringhe visualizzate nella scheda \"Variabili\" o \"Console di Debug\", stringhe più lunghe di questo numero verranno tagliate, se 0 nessun taglio viene eseguito.",
     "java.debugger.configuration.enableHotCodeReplace.description": "Attiva sostituzione hotcode per codice Java.",
-    "java.debugger.configuration.enableRunDebugCodeLens.description": "Abilitare i provider di lenti di codice run e debug sui metodi principali"
+    "java.debugger.configuration.enableRunDebugCodeLens.description": "Abilitare i provider di lenti di codice run e debug sui metodi principali."
 }

--- a/package.nls.it.json
+++ b/package.nls.it.json
@@ -4,7 +4,7 @@
     "java.debugger.configuration.showHex.description": "Mostra numeri in formato esadecimale nella scheda \"variabili\".",
     "java.debugger.configuration.showStaticVariables.description": "Mostra variabili statiche nella scheda \"variabili\".",
     "java.debugger.configuration.showQualifiedNames.description": "Mostra nome completo delle classi nella scheda \"variabili\".",
-    "java.debugger.configuration.maxStringLength.description": "Lunghezza massima delle stringhe visualizzate nella scheda \"Variabili\" o \"Console di Debug\", stringhe più lunghe di questo numero verranno tagliate, se 0 nessun taglio viene eseguito.",                                                      
-    "java.debugger.configuration.enableHotCodeReplace.description": "Attiva sostituzione hotcode per codice Java."
-                                                                    
+    "java.debugger.configuration.maxStringLength.description": "Lunghezza massima delle stringhe visualizzate nella scheda \"Variabili\" o \"Console di Debug\", stringhe più lunghe di questo numero verranno tagliate, se 0 nessun taglio viene eseguito.",
+    "java.debugger.configuration.enableHotCodeReplace.description": "Attiva sostituzione hotcode per codice Java.",
+    "java.debugger.configuration.enableRunDebugCodeLens.description": "Abilitare i provider di lenti di codice run e debug sui metodi principali"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -5,5 +5,6 @@
     "java.debugger.configuration.showStaticVariables.description": "Show static variables in \"Variables\" viewlet.",
     "java.debugger.configuration.showQualifiedNames.description": "Show fully qualified class names in \"Variables\" viewlet.",
     "java.debugger.configuration.maxStringLength.description": "The maximum length of strings displayed in \"Variables\" or \"Debug Console\" viewlet, strings longer than this length will be trimmed, if 0 no trim is performed.",
-    "java.debugger.configuration.enableHotCodeReplace.description": "Enable hot code replace for Java code."
+    "java.debugger.configuration.enableHotCodeReplace.description": "Enable hot code replace for Java code.",
+    "java.debugger.configuration.enableRunDebugCodeLens.description": "Enable the run and debug code lens providers over main methods"
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -6,5 +6,5 @@
     "java.debugger.configuration.showQualifiedNames.description": "Show fully qualified class names in \"Variables\" viewlet.",
     "java.debugger.configuration.maxStringLength.description": "The maximum length of strings displayed in \"Variables\" or \"Debug Console\" viewlet, strings longer than this length will be trimmed, if 0 no trim is performed.",
     "java.debugger.configuration.enableHotCodeReplace.description": "Enable hot code replace for Java code.",
-    "java.debugger.configuration.enableRunDebugCodeLens.description": "Enable the run and debug code lens providers over main methods"
+    "java.debugger.configuration.enableRunDebugCodeLens.description": "Enable the run and debug code lens providers over main methods."
 }

--- a/src/debugCodeLensProvider.ts
+++ b/src/debugCodeLensProvider.ts
@@ -11,11 +11,53 @@ import * as utility from "./utility";
 
 const JAVA_RUN_COMMAND = "vscode.java.run";
 const JAVA_DEBUG_COMMAND = "vscode.java.debug";
+const JAVA_DEBUG_CONFIGURATION = "java.debug.settings";
+const ENABLE_CODE_LENS_VARIABLE = "enableRunDebugCodeLens";
 
 export function initializeCodeLensProvider(context: vscode.ExtensionContext): void {
-    context.subscriptions.push(vscode.languages.registerCodeLensProvider(JAVA_LANGID, new DebugCodeLensProvider()));
-    context.subscriptions.push(vscode.commands.registerCommand(JAVA_RUN_COMMAND, runJavaProgram));
-    context.subscriptions.push(vscode.commands.registerCommand(JAVA_DEBUG_COMMAND, debugJavaProgram));
+    context.subscriptions.push(new DebugCodeLensContainer());
+}
+
+class DebugCodeLensContainer implements vscode.Disposable {
+    private runCommand: vscode.Disposable;
+    private debugCommand: vscode.Disposable;
+    private lensProvider: vscode.Disposable | undefined;
+    private configurationEvent: vscode.Disposable;
+
+    constructor() {
+        this.runCommand = vscode.commands.registerCommand(JAVA_RUN_COMMAND, runJavaProgram);
+        this.debugCommand = vscode.commands.registerCommand(JAVA_DEBUG_COMMAND, debugJavaProgram);
+
+        const configuration = vscode.workspace.getConfiguration(JAVA_DEBUG_CONFIGURATION)
+        const isCodeLensEnabled = configuration.get<boolean>(ENABLE_CODE_LENS_VARIABLE);
+
+        if (isCodeLensEnabled) {
+            this.lensProvider = vscode.languages.registerCodeLensProvider(JAVA_LANGID, new DebugCodeLensProvider());
+        }
+
+        this.configurationEvent = vscode.workspace.onDidChangeConfiguration((event) =>  {
+            if (event.affectsConfiguration(JAVA_DEBUG_CONFIGURATION)) {
+                const newConfiguration = vscode.workspace.getConfiguration(JAVA_DEBUG_CONFIGURATION);
+                const newEnabled = newConfiguration.get<boolean>(ENABLE_CODE_LENS_VARIABLE);
+                if (newEnabled && this.lensProvider === undefined) {
+                    this.lensProvider = vscode.languages.registerCodeLensProvider(JAVA_LANGID, new DebugCodeLensProvider());
+                } else if (!newEnabled && this.lensProvider !== undefined) {
+                    this.lensProvider.dispose();
+                    this.lensProvider = undefined;
+                }
+            }
+        }, this);
+    }
+
+    public dispose() {
+        if (this.lensProvider !== undefined) {
+            this.lensProvider.dispose();
+        }
+        this.runCommand.dispose();
+        this.debugCommand.dispose();
+        this.configurationEvent.dispose();
+    }
+
 }
 
 class DebugCodeLensProvider implements vscode.CodeLensProvider {

--- a/src/debugCodeLensProvider.ts
+++ b/src/debugCodeLensProvider.ts
@@ -35,7 +35,7 @@ class DebugCodeLensContainer implements vscode.Disposable {
             this.lensProvider = vscode.languages.registerCodeLensProvider(JAVA_LANGID, new DebugCodeLensProvider());
         }
 
-        this.configurationEvent = vscode.workspace.onDidChangeConfiguration((event) =>  {
+        this.configurationEvent = vscode.workspace.onDidChangeConfiguration((event: vscode.ConfigurationChangeEvent) =>  {
             if (event.affectsConfiguration(JAVA_DEBUG_CONFIGURATION)) {
                 const newConfiguration = vscode.workspace.getConfiguration(JAVA_DEBUG_CONFIGURATION);
                 const newEnabled = newConfiguration.get<boolean>(ENABLE_CODE_LENS_VARIABLE);


### PR DESCRIPTION
There are cases where it will never work properly, and it is confusing a chunk of my users that attempt to use it, and wonder why it fails.

Closes #464