### PR TITLE
Support for an alternative jvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Please also check the documentation of [Language Support for Java by Red Hat](ht
 - `modulePaths` - The modulepaths for launching the JVM. If not specified, the debugger will automatically resolve from current project.
 - `classPaths` - The classpaths for launching the JVM. If not specified, the debugger will automatically resolve from current project.
 - `encoding` - The `file.encoding` setting for the JVM. If not specified, 'UTF-8' will be used. Possible values can be found in http://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html.
+- `javaHome` - Lauch your application against an alternative JVM than the one running the Langauge Server.
+  - For example, to test against a 32-bit JVM, or a completely different JDK Version or Build than the Language Server is currently running on.
 - `vmArgs` - The extra options and system properties for the JVM (e.g. -Xms\<size\> -Xmx\<size\> -D\<name\>=\<value\>), it accepts a string or an array of string.
 - `projectName` - The preferred project in which the debugger searches for classes. There could be duplicated class names in different projects. This setting also works when the debugger looks for the specified main class when launching a program. It is required when the workspace has multiple java projects, otherwise the expression evaluation and conditional breakpoint may not work.
 - `cwd` - The working directory of the program. Defaults to `${workspaceFolder}`.

--- a/package.json
+++ b/package.json
@@ -157,6 +157,11 @@
                 "description": "%java.debugger.launch.stopOnEntry.description%",
                 "default": true
               },
+              "javaHome": {
+                "type": "string",
+                "description": "Path to an alternative JVM to run on. For example, Java Language Server is running on JDK 8 64-bit, but your app only works on 32-bit",
+                "default": "^\"\\${env:JAVA_HOME}\""
+              },
               "console": {
                 "type": "string",
                 "enum": [

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -19,6 +19,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
     private isUserSettingsDirty: boolean = true;
     private debugHistory: MostRecentlyUsedHistory = new MostRecentlyUsedHistory();
     private resolver: VariableResolver;
+
     constructor() {
         this.resolver = new VariableResolver();
         vscode.workspace.onDidChangeConfiguration((event) => {
@@ -95,7 +96,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
     private resolveVariables(folder: vscode.WorkspaceFolder, config: vscode.DebugConfiguration): void {
         // all the properties whose values are string or array of string
         const keys = ["mainClass", "args", "vmArgs", "modulePaths", "classPaths", "projectName",
-            "env", "sourcePaths", "encoding", "cwd", "hostName"];
+            "env", "sourcePaths", "encoding", "cwd", "hostName", "javaHome"];
         if (!config) {
             return;
         }
@@ -131,7 +132,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
         try {
             if (this.isUserSettingsDirty) {
                 this.isUserSettingsDirty = false;
-                await updateDebugSettings();
+                await updateDebugSettings(config);
             }
 
             /**
@@ -202,6 +203,9 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                         type: Type.USAGEERROR,
                     });
                 }
+                if (!_.isEmpty(config.javaHome) && !fs.existsSync(config.javaHome)) {
+                    config.javaHome = "";
+                }
 
                 // Add the default launch options to the config.
                 config.cwd = config.cwd || _.get(folder, "uri.fsPath");
@@ -216,6 +220,10 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                         type: Type.USAGEERROR,
                         anchor: anchor.ATTACH_CONFIG_ERROR,
                     });
+                }
+                // This doesn't make sense with an attached debugger
+                if (!_.isEmpty(config.javaHome)) {
+                    config.javaHome = "";
                 }
             } else {
                 throw new utility.UserError({
@@ -491,13 +499,13 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
     }
 }
 
-async function updateDebugSettings() {
+async function updateDebugSettings(config?: vscode.DebugConfiguration | undefined) {
     const debugSettingsRoot: vscode.WorkspaceConfiguration = vscode.workspace.getConfiguration("java.debug");
     if (!debugSettingsRoot) {
         return;
     }
     const logLevel = convertLogLevel(debugSettingsRoot.logLevel || "");
-    const javaHome = await utility.getJavaHome();
+    const javaHome = (config && config.javaHome) ? config.javaHome : await utility.getJavaHome();
     if (debugSettingsRoot.settings && Object.keys(debugSettingsRoot.settings).length) {
         try {
             console.log("settings:", await commands.executeJavaLanguageServerCommand(commands.JAVA_UPDATE_DEBUG_SETTINGS, JSON.stringify(


### PR DESCRIPTION
* Added new launch configuration property `jvm`
* Changed `updateDebugSettings` to optionally take in the config object
  - uses `config.jvm` if available instead for calling `getJavaHome`