### PR TITLE
Refine the launch json

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Please also check the documentation of [Language Support for Java by Red Hat](ht
 
 ### Launch
 
-- `mainClass` (required) - The main class of the program (fully qualified name, e.g. [mymodule/]com.xyz.MainClass).
+- `mainClass` (required) - The fully qualified class name (e.g. [java module name/]com.xyz.MainApp) or the java file path of the program entry.
 - `args` - The command line arguments passed to the program. Use `"${command:SpecifyProgramArgs}"` to prompt for program arguments. It accepts a string or an array of string.
 - `sourcePaths` - The extra source directories of the program. The debugger looks for source code from project settings by default. This option allows the debugger to look for source code in extra directories.
 - `modulePaths` - The modulepaths for launching the JVM. If not specified, the debugger will automatically resolve from current project.
@@ -56,7 +56,7 @@ Please also check the documentation of [Language Support for Java by Red Hat](ht
 - `encoding` - The `file.encoding` setting for the JVM. If not specified, 'UTF-8' will be used. Possible values can be found in http://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html.
 - `vmArgs` - The extra options and system properties for the JVM (e.g. -Xms\<size\> -Xmx\<size\> -D\<name\>=\<value\>), it accepts a string or an array of string.
 - `projectName` - The preferred project in which the debugger searches for classes. There could be duplicated class names in different projects. This setting also works when the debugger looks for the specified main class when launching a program. It is required when the workspace has multiple java projects, otherwise the expression evaluation and conditional breakpoint may not work.
-- `cwd` - The working directory of the program.
+- `cwd` - The working directory of the program. Defaults to `${workspaceFolder}`.
 - `env` - The extra environment variables for the program.
 - `stopOnEntry` - Automatically pause the program after launching.
 - `console` - The specified console to launch the program. Defaults to `internalConsole`.

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
               },
               "mainClass": {
                 "type": "string",
-                "description": "The main class of the program (fully qualified name, e.g. [mymodule/]com.xyz.MainClass).",
+                "description": "The fully qualified class name (e.g. [java module name/]com.xyz.MainApp) or the java file path of the program entry.",
                 "default": ""
               },
               "args": {
@@ -118,7 +118,7 @@
               },
               "cwd": {
                 "type": "string",
-                "description": "The working directory of the program.",
+                "description": "The working directory of the program. Defaults to current workspace root.",
                 "default": "${workspaceFolder}"
               },
               "env": {
@@ -290,10 +290,20 @@
               "type": "java",
               "name": "Debug (Launch)",
               "request": "launch",
-              "cwd": "^\"\\${workspaceFolder}\"",
               "console": "internalConsole",
-              "stopOnEntry": false,
               "mainClass": "",
+              "args": ""
+            }
+          },
+          {
+            "label": "Java: Launch Program in Current File",
+            "description": "Add a new configuration for launching current java file.",
+            "body": {
+              "type": "java",
+              "name": "Debug (Launch) - Current File",
+              "request": "launch",
+              "console": "internalConsole",
+              "mainClass": "^\"\\${file}\"",
               "args": ""
             }
           },
@@ -304,9 +314,7 @@
               "type": "java",
               "name": "Debug (Launch) with Arguments Prompt",
               "request": "launch",
-              "cwd": "^\"\\${workspaceFolder}\"",
               "console": "internalConsole",
-              "stopOnEntry": false,
               "mainClass": "",
               "args": "^\"\\${command:SpecifyProgramArgs}\""
             }

--- a/src/languageServerPlugin.ts
+++ b/src/languageServerPlugin.ts
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import * as vscode from "vscode";
+
+import * as commands from "./commands";
+import { logger, Type } from "./logger";
+import * as utility from "./utility";
+
+export interface IMainClassOption {
+    readonly mainClass: string;
+    readonly projectName?: string;
+    readonly filePath?: string;
+}
+
+export interface IMainMethod extends IMainClassOption {
+    range: vscode.Range;
+}
+
+export interface IValidationResult {
+    readonly isValid: boolean;
+    readonly message?: string;
+}
+
+export interface ILaunchValidationResponse {
+    readonly mainClass: IValidationResult;
+    readonly projectName: IValidationResult;
+    readonly proposals?: IMainClassOption[];
+}
+
+export async function resolveMainMethod(uri: vscode.Uri): Promise<IMainMethod[]> {
+    try {
+        return <IMainMethod[]> await commands.executeJavaLanguageServerCommand(commands.JAVA_RESOLVE_MAINMETHOD, uri.toString());
+    } catch (ex) {
+        logger.log(Type.EXCEPTION, utility.formatErrorProperties(ex));
+        return [];
+    }
+}
+
+export function startDebugSession() {
+    return commands.executeJavaLanguageServerCommand(commands.JAVA_START_DEBUGSESSION);
+}
+
+export function resolveClasspath(mainClass, projectName) {
+    return commands.executeJavaLanguageServerCommand(commands.JAVA_RESOLVE_CLASSPATH, mainClass, projectName);
+}
+
+export function resolveMainClass(workspaceUri: vscode.Uri): Promise<IMainClassOption[]> {
+    if (workspaceUri) {
+        return <Promise<IMainClassOption[]>>commands.executeJavaLanguageServerCommand(commands.JAVA_RESOLVE_MAINCLASS, workspaceUri.toString());
+    }
+    return <Promise<IMainClassOption[]>>commands.executeJavaLanguageServerCommand(commands.JAVA_RESOLVE_MAINCLASS);
+}
+
+export function validateLaunchConfig(workspaceUri: vscode.Uri, mainClass: string, projectName: string, containsExternalClasspaths: boolean):
+    Promise<ILaunchValidationResponse> {
+    return <Promise<ILaunchValidationResponse>>commands.executeJavaLanguageServerCommand(commands.JAVA_VALIDATE_LAUNCHCONFIG,
+        workspaceUri ? workspaceUri.toString() : undefined, mainClass, projectName, containsExternalClasspaths);
+}

--- a/src/variableResolver.ts
+++ b/src/variableResolver.ts
@@ -110,7 +110,6 @@ export class VariableResolver {
 
                     // common error handling for all variables that require an open file
                     switch (variable) {
-                        case "file":
                         case "relativeFile":
                         case "fileDirname":
                         case "fileExtname":
@@ -153,7 +152,7 @@ export class VariableResolver {
                                 ` Make sure to have some text selected in the active editor.`);
 
                         case "file":
-                            return filePath;
+                            return filePath || "";
 
                         case "relativeFile":
                             if (folderUri) {


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

It's for issue `Simplify generated launch.json` #476 and `Introduce shortcut to launch program from active editor` #431.

3 refinements:
- Don't generate `cwd` and `stopOnEntry` by default, but keep `hostName` because it's easy to understand and no burden on learning curve.
- Provide shortcut to launch program from active editor. The user could specify `mainClass: "${file}"` for that, `F5` will auto detect main class from current file.
- Refine the hint message when prompting for main class.

