### PR TITLE
Add a user setting to control whether to show variable's toString value

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Please also check the documentation of [Language Support for Java by Red Hat](ht
 - `java.debug.settings.showStaticVariables`: show static variables in "Variables" viewlet, defaults to `false`.
 - `java.debug.settings.showQualifiedNames`: show fully qualified class names in "Variables" viewlet, defaults to `false`.
 - `java.debug.settings.showLogicalStructure`: show the logical structure for the Collection and Map classes in "Variables" viewlet, defaults to `true`.
+- `java.debug.settings.showToString`: show 'toString()' value for all classes that override 'toString' method in "Variables" viewlet, defaults to `true`.
 - `java.debug.settings.maxStringLength`: the maximum length of string displayed in "Variables" or "Debug Console" viewlet, the string longer than this length will be trimmed, defaults to `0` which means no trim is performed.
 - `java.debug.settings.hotCodeReplace`: Reload the changed Java classes during debugging, defaults to `manual`. Make sure `java.autobuild.enabled` is not disabled for [VSCode Java](https://github.com/redhat-developer/vscode-java). See the [wiki page](https://github.com/Microsoft/vscode-java-debug/wiki/Hot-Code-Replace) for more information about usages and limitations.
   - manual - Click the toolbar to apply the changes.

--- a/package.json
+++ b/package.json
@@ -428,6 +428,11 @@
           "description": "%java.debugger.configuration.showLogicalStructure.description%",
           "default": true
         },
+        "java.debug.settings.showToString": {
+          "type": "boolean",
+          "description": "%java.debugger.configuration.showToString.description%",
+          "default": true
+        },
         "java.debug.settings.maxStringLength": {
           "type": "number",
           "description": "%java.debugger.configuration.maxStringLength.description%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -40,6 +40,7 @@
     "java.debugger.configuration.showStaticVariables.description": "Show static variables in \"Variables\" viewlet.",
     "java.debugger.configuration.showQualifiedNames.description": "Show fully qualified class names in \"Variables\" viewlet.",
     "java.debugger.configuration.showLogicalStructure.description": "Show the logical structure for the Collection and Map classes in \"Variables\" viewlet.",
+    "java.debugger.configuration.showToString.description": "Show 'toString()' value for all classes that override 'toString' method in \"Variables\" viewlet.",
     "java.debugger.configuration.maxStringLength.description": "The maximum length of strings displayed in \"Variables\" or \"Debug Console\" viewlet, strings longer than this length will be trimmed, if 0 no trim is performed.",
     "java.debugger.configuration.hotCodeReplace.description": "Reload the changed Java classes during debugging. Make sure 'java.autobuild.enabled' is not disabled.",
     "java.debugger.configuration.enableRunDebugCodeLens.description": "Enable the run and debug code lens providers over main methods.",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -40,6 +40,7 @@
     "java.debugger.configuration.showStaticVariables.description": "在“变量”视图中显示静态变量。",
     "java.debugger.configuration.showQualifiedNames.description": "在“变量”视图中显示类的全名。",
     "java.debugger.configuration.showLogicalStructure.description": "在“变量”视图中显示Collection和Map类的逻辑结构。",
+    "java.debugger.configuration.showToString.description": "在“变量”视图中显示所有重载过'toString'方法的类的'toString()'值。",
     "java.debugger.configuration.maxStringLength.description": "设定“变量”或“调试控制台”视图中显示的字符串最大长度，长度超过部分将被剪掉。如果值为0，则不执行修剪。",
     "java.debugger.configuration.hotCodeReplace.description": "在调试期间重新加载已更改的Java类。确保未禁用'java.autobuild.enabled'。",
     "java.debugger.configuration.enableRunDebugCodeLens.description": "在main方法上启用CodeLens标记。",


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Below is the new setting:
`java.debug.settings.showToString`: show 'toString()' value for all classes that override 'toString' method in "Variables" viewlet, defaults to `true`.

Close #315 
Close #364