### PR TITLE
Fix the case HCR button doesn't take effect if auto build is temporarily enabled

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,8 +56,12 @@ function initializeExtension(operationId: string, context: vscode.ExtensionConte
                 "Yes", "No");
             if (ans === "Yes") {
                 await autobuildConfig.update("enabled", true);
-            } else {
-                return;
+                // Force an incremental build to avoid auto build is not finishing during HCR.
+                try {
+                    await vscode.commands.executeCommand(commands.JAVA_BUILD_WORKSPACE, false)
+                } catch (err) {
+                    // do nothing.
+                }
             }
         }
 


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>