### PR TITLE
Disable querying usage data when on terminating non-java sessions

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,10 @@ function initializeExtension(operationId: string, context: vscode.ExtensionConte
     });
 
     const measureKeys = ["duration"];
-    vscode.debug.onDidTerminateDebugSession(() => {
+    vscode.debug.onDidTerminateDebugSession((e) => {
+        if (e.type !== "java") {
+            return;
+        }
         fetchUsageData().then((ret) => {
             if (Array.isArray(ret) && ret.length) {
                 ret.forEach((entry) => {


### PR DESCRIPTION
Signed-off-by: Yan Zhang <yanzh@microsoft.com>

No need to query for usage data when a debug session of another language is terminated.