### PR TITLE
Fix: Property enableBreakpointsFor is not allowed.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,11 @@
   ],
   "main": "./dist/extension",
   "contributes": {
+    "breakpoints": [
+      {
+        "language": "java"
+      }
+    ],
     "javaExtensions": [
       "./server/com.microsoft.java.debug.plugin-0.20.0.jar"
     ],
@@ -73,11 +78,6 @@
         "languages": [
           "java"
         ],
-        "enableBreakpointsFor": {
-          "languageIds": [
-            "java"
-          ]
-        },
         "variables": {
           "SpecifyProgramArgs": "JavaDebug.SpecifyProgramArgs"
         },


### PR DESCRIPTION
`enableBreakpointsFor` is deprecated.

See example: https://code.visualstudio.com/api/extension-guides/debugger-extension#anatomy-of-the-package.json-of-a-debugger-extension
