### PR TITLE
Use a bat launcher to set page code

### DIFF
--- a/scripts/launcher.bat
+++ b/scripts/launcher.bat
@@ -1,0 +1,7 @@
+@echo off
+
+REM Change code page to UTF-8 for better compatibility.
+@chcp.com 65001 > NUL 
+
+REM Execute real command passed by args
+%*

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -237,6 +237,10 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                 config.shortenCommandLine = await detectLaunchCommandStyle(config);
             }
 
+            if (process.platform === "win32" && config.request === "launch" && config.console !== "internalConsole") {
+                config.launcherScript = utility.getLauncherScriptPath();
+            }
+
             const debugServerPort = await lsPlugin.startDebugSession();
             if (debugServerPort) {
                 config.debugServer = debugServerPort;

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
+import * as path from "path";
 import * as vscode from "vscode";
 import { setUserError } from "vscode-extension-telemetry-wrapper";
 import { logger, Type } from "./logger";
@@ -8,6 +9,7 @@ import { logger, Type } from "./logger";
 const TROUBLESHOOTING_LINK = "https://github.com/Microsoft/vscode-java-debug/blob/master/Troubleshooting.md";
 const LEARN_MORE = "Learn More";
 const JAVA_EXTENSION_ID = "redhat.java";
+const DEBUGGER_EXTENSION_ID = "vscjava.vscode-java-debug";
 
 export class UserError extends Error {
     public context: ITroubleshootingMessage;
@@ -155,4 +157,9 @@ export async function getJavaHome(): Promise<string> {
 export function isJavaExtEnabled() {
     const javaExt = vscode.extensions.getExtension(JAVA_EXTENSION_ID);
     return !!javaExt;
+}
+
+export function getLauncherScriptPath() {
+    const ext = vscode.extensions.getExtension(DEBUGGER_EXTENSION_ID);
+    return path.join(ext.extensionPath, "scripts", "launcher.bat");
 }


### PR DESCRIPTION
See: #622 #618 
Require: https://github.com/microsoft/java-debug/pull/288

When runing in Windows terminal, use a launcher to set page code to UTF-8.
