### PR TITLE
User face change: say "Do not show again" instead of "Not show again".

### DIFF
--- a/src/hotCodeReplace.ts
+++ b/src/hotCodeReplace.ts
@@ -13,7 +13,7 @@ const YES_BUTTON: string = "Yes";
 
 const NO_BUTTON: string = "No";
 
-const NEVER_BUTTON: string = "Not show again";
+const NEVER_BUTTON: string = "Do not show again";
 
 enum HcrChangeType {
     ERROR = "ERROR",


### PR DESCRIPTION
Typo fix because simply saying "Not show again" is weird to the user.