### PR TITLE
Don't support HCR in Run mode

### DIFF
--- a/src/hotCodeReplace.ts
+++ b/src/hotCodeReplace.ts
@@ -9,9 +9,9 @@ import * as utility from "./utility";
 
 const suppressedReasons: Set<string> = new Set();
 
-const YES_BUTTON: string = "Yes";
+export const YES_BUTTON: string = "Yes";
 
-const NO_BUTTON: string = "No";
+export const NO_BUTTON: string = "No";
 
 const NEVER_BUTTON: string = "Do not show again";
 


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

In Run mode, click ⚡ in debug toolbar, actually HCR will do nothing because we don't support hot replace in running mode.

An improvement is to show a message about the limitation.
![image](https://user-images.githubusercontent.com/14052197/65313408-e1cfa480-dbc6-11e9-84a7-9d32f50d01a9.png)

