### PR TITLE
Prompt to add the folder to source path if the running file isn't on classpath

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -34,6 +34,8 @@ export const JAVA_RESOLVE_ELEMENT_AT_SELECTION = "vscode.java.resolveElementAtSe
 
 export const JAVA_RESOLVE_BUILD_FILES = "vscode.java.resolveBuildFiles";
 
+export const JAVA_IS_ON_CLASSPATH = "vscode.java.isOnClasspath";
+
 export function executeJavaLanguageServerCommand(...rest) {
     // TODO: need to handle error and trace telemetry
     if (!utility.isJavaExtEnabled()) {

--- a/src/debugCodeLensProvider.ts
+++ b/src/debugCodeLensProvider.ts
@@ -169,8 +169,8 @@ async function constructDebugConfig(mainClass: string, projectName: string, work
 export async function startDebugging(mainClass: string, projectName: string, uri: vscode.Uri, noDebug: boolean): Promise<boolean> {
     const workspaceFolder: vscode.WorkspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
     const workspaceUri: vscode.Uri = workspaceFolder ? workspaceFolder.uri : undefined;
-
-    if (workspaceUri && !(await isOnClasspath(uri.toString())) && !(await addToClasspath(uri))) {
+    const onClasspath = await isOnClasspath(uri.toString());
+    if (workspaceUri && onClasspath === false && !(await addToClasspath(uri))) {
         return false;
     }
 
@@ -195,10 +195,11 @@ async function addToClasspath(uri: vscode.Uri): Promise<boolean> {
     }
     const ans = await vscode.window.showWarningMessage(`The file ${fileName} isn't on the classpath, the runtime may throw class not found error. `
         + `Do you want to add the parent folder "${parentPath}" to Java source path?`, "Add to Source Path", "Skip");
-    if (ans === "Add to Source Path") {
+    if (ans === "Skip") {
+        return true;
+    } else if (ans === "Add to Source Path") {
         vscode.commands.executeCommand("java.project.addToSourcePath", parentUri);
-        return false;
     }
 
-    return true;
+    return false;
 }

--- a/src/debugCodeLensProvider.ts
+++ b/src/debugCodeLensProvider.ts
@@ -193,8 +193,8 @@ async function addToClasspath(uri: vscode.Uri): Promise<boolean> {
     if (parentPath === parentUri.fsPath) {
         parentPath = path.basename(parentFsPath);
     }
-    const ans = await vscode.window.showWarningMessage(`The file ${fileName} isn't on the classpath, the runtime may throw class not found error. Do you want to add the parent folder "${parentPath}" to Java source path?`,
-        "Add to Source Path", "Skip");
+    const ans = await vscode.window.showWarningMessage(`The file ${fileName} isn't on the classpath, the runtime may throw class not found error. `
+        + `Do you want to add the parent folder "${parentPath}" to Java source path?`, "Add to Source Path", "Skip");
     if (ans === "Add to Source Path") {
         vscode.commands.executeCommand("java.project.addToSourcePath", parentUri);
         return false;

--- a/src/debugCodeLensProvider.ts
+++ b/src/debugCodeLensProvider.ts
@@ -2,12 +2,13 @@
 // Licensed under the MIT license.
 
 import * as _ from "lodash";
+import * as path from "path";
 import * as vscode from "vscode";
 import { instrumentOperationAsVsCodeCommand } from "vscode-extension-telemetry-wrapper";
 
 import { JAVA_LANGID } from "./constants";
 import { initializeHoverProvider } from "./hoverProvider";
-import { IMainMethod, resolveMainMethod } from "./languageServerPlugin";
+import { IMainMethod, isOnClasspath, resolveMainMethod } from "./languageServerPlugin";
 import { getJavaExtensionAPI, isJavaExtEnabled } from "./utility";
 
 const JAVA_RUN_CODELENS_COMMAND = "java.debug.runCodeLens";
@@ -169,9 +170,35 @@ export async function startDebugging(mainClass: string, projectName: string, uri
     const workspaceFolder: vscode.WorkspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
     const workspaceUri: vscode.Uri = workspaceFolder ? workspaceFolder.uri : undefined;
 
+    if (workspaceUri && !(await isOnClasspath(uri.toString())) && !(await addToClasspath(uri))) {
+        return false;
+    }
+
     const debugConfig: vscode.DebugConfiguration = await constructDebugConfig(mainClass, projectName, workspaceUri);
     debugConfig.projectName = projectName;
     debugConfig.noDebug = noDebug;
 
     return vscode.debug.startDebugging(workspaceFolder, debugConfig);
+}
+
+async function addToClasspath(uri: vscode.Uri): Promise<boolean> {
+    const fileName = path.basename(uri.fsPath || "");
+    const parentFsPath = path.dirname(uri.fsPath || "");
+    if (!parentFsPath) {
+        return true;
+    }
+
+    const parentUri = vscode.Uri.file(parentFsPath);
+    let parentPath = vscode.workspace.asRelativePath(parentUri, true);
+    if (parentPath === parentUri.fsPath) {
+        parentPath = path.basename(parentFsPath);
+    }
+    const ans = await vscode.window.showWarningMessage(`The file ${fileName} isn't on the classpath, the runtime may throw class not found error. Do you want to add the parent folder "${parentPath}" to Java source path?`,
+        "Add to Source Path", "Skip");
+    if (ans === "Add to Source Path") {
+        vscode.commands.executeCommand("java.project.addToSourcePath", parentUri);
+        return false;
+    }
+
+    return true;
 }

--- a/src/languageServerPlugin.ts
+++ b/src/languageServerPlugin.ts
@@ -88,3 +88,11 @@ export function resolveElementAtSelection(uri: string, line: number, character: 
 export function resolveBuildFiles(): Promise<string[]> {
     return <Promise<string[]>>commands.executeJavaLanguageServerCommand(commands.JAVA_RESOLVE_BUILD_FILES);
 }
+
+export async function isOnClasspath(uri: string): Promise<boolean> {
+    try {
+        return <boolean> await commands.executeJavaExtensionCommand(commands.JAVA_IS_ON_CLASSPATH, uri);
+    } catch (error) {
+        return true;
+    }
+}


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

It requires https://github.com/microsoft/java-debug/pull/302
Close #470

When the Java file isn't on the source path of any project, JDT doesn't build it to .class. Run it via codelens or context menu, the runtime will throw class not found error. One improvement is to provide a fix option to ask user to add the parent folder to Java source path.