### PR TITLE
Use HTTPS wherever possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Change Log
 All notable changes to the "vscode-java-debugger" extension will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
-and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.23.0 - 2019-10-29
 ### Added

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Please also check the documentation of [Language Support for Java by Red Hat](ht
 - `sourcePaths` - The extra source directories of the program. The debugger looks for source code from project settings by default. This option allows the debugger to look for source code in extra directories.
 - `modulePaths` - The modulepaths for launching the JVM. If not specified, the debugger will automatically resolve from current project.
 - `classPaths` - The classpaths for launching the JVM. If not specified, the debugger will automatically resolve from current project.
-- `encoding` - The `file.encoding` setting for the JVM. If not specified, 'UTF-8' will be used. Possible values can be found in http://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html.
+- `encoding` - The `file.encoding` setting for the JVM. If not specified, 'UTF-8' will be used. Possible values can be found in https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html.
 - `vmArgs` - The extra options and system properties for the JVM (e.g. -Xms\<size\> -Xmx\<size\> -D\<name\>=\<value\>), it accepts a string or an array of string.
 - `projectName` - The preferred project in which the debugger searches for classes. There could be duplicated class names in different projects. This setting also works when the debugger looks for the specified main class when launching a program. It is required when the workspace has multiple java projects, otherwise the expression evaluation and conditional breakpoint may not work.
 - `cwd` - The working directory of the program. Defaults to `${workspaceFolder}`.

--- a/package.nls.json
+++ b/package.nls.json
@@ -6,7 +6,7 @@
     "java.debugger.launch.modulePaths.description": "The modulepaths for launching the JVM. If not specified, the debugger will automatically resolve from current project.",
     "java.debugger.launch.classPaths.description": "The classpaths for launching the JVM. If not specified, the debugger will automatically resolve from current project.",
     "java.debugger.launch.sourcePaths.description": "The extra source directories of the program. The debugger looks for source code from project settings by default. This option allows the debugger to look for source code in extra directories.",
-    "java.debugger.launch.encoding.description": "The file.encoding setting for the JVM. If not specified, 'UTF-8' will be used. Possible values can be found in http://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html.",
+    "java.debugger.launch.encoding.description": "The file.encoding setting for the JVM. If not specified, 'UTF-8' will be used. Possible values can be found in https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html.",
     "java.debugger.launch.cwd.description": "The working directory of the program. Defaults to the current workspace root.",
     "java.debugger.launch.env.description": "The extra environment variables for the program.",
     "java.debugger.launch.stopOnEntry.description": "Automatically pause the program after launching.",


### PR DESCRIPTION
These links are changed to HTTPS:
* https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html
* https://keepachangelog.com/en/1.0.0/
* https://semver.org/spec/v2.0.0.html