### PR TITLE
Generate the launch configuration in memory if no launch.json exists

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -49,9 +49,9 @@
             "dev": true
         },
         "@types/vscode": {
-            "version": "1.32.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.32.0.tgz",
-            "integrity": "sha512-fpHR6iE38V3+2ezMwopt726uRYKK9c89OQDO+t8VEUXNJCaYvnMFbHYgxXvQ/jOvP2ZanlL6r6joRZlsUowzoA==",
+            "version": "1.38.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.38.0.tgz",
+            "integrity": "sha512-aGo8LQ4J1YF0T9ORuCO+bhQ5sGR1MXa7VOyOdEP685se3wyQWYUExcdiDi6rvaK61KUwfzzA19JRLDrUbDl7BQ==",
             "dev": true
         },
         "@webassemblyjs/ast": {
@@ -388,7 +388,7 @@
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
             "dev": true
         },
         "arr-map": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "debugger"
   ],
   "engines": {
-    "vscode": "^1.32.0"
+    "vscode": "^1.38.0"
   },
   "license": "SEE LICENSE IN LICENSE.txt",
   "repository": {
@@ -529,7 +529,7 @@
     "@types/lodash": "^4.14.137",
     "@types/mocha": "^5.2.7",
     "@types/node": "^8.10.51",
-    "@types/vscode": "1.32.0",
+    "@types/vscode": "1.38.0",
     "cross-env": "^5.2.0",
     "gulp": "^4.0.2",
     "gulp-tslint": "^8.1.4",

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -379,8 +379,9 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
     private async promptMainClass(folder: vscode.Uri | undefined, hintMessage?: string): Promise<lsPlugin.IMainClassOption | undefined> {
         const res = await lsPlugin.resolveMainClass(folder);
         if (res.length === 0) {
+            const workspaceFolder = folder ? vscode.workspace.getWorkspaceFolder(folder) : undefined;
             throw new utility.UserError({
-                message: "Cannot find a class with the main method.",
+                message: `Cannot find a class with the main method${ workspaceFolder ? " in the folder '" + workspaceFolder.name + "'" : ""}.`,
                 type: Type.USAGEERROR,
                 anchor: anchor.CANNOT_FIND_MAIN_CLASS,
             });

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -135,18 +135,8 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                 await updateDebugSettings();
             }
 
-            /**
-             * If no launch.json exists in the current workspace folder
-             * delegate to provideDebugConfigurations api to generate the initial launch.json configurations
-             */
-            if (this.isEmptyConfig(config) && folder) {
-                // Follow the feature request https://github.com/Microsoft/vscode/issues/54213#issuecomment-420965778,
-                // in order to generate launch.json, the resolveDebugConfiguration api must return null explicitly.
-                return null;
-            }
-
-            // If it's the single file case that no workspace folder is opened, generate debug config in memory
-            if (this.isEmptyConfig(config) && !folder) {
+            // If no debug configuration is provided, then generate one in memory.
+            if (this.isEmptyConfig(config)) {
                 config.type = "java";
                 config.name = "Java Debug";
                 config.request = "launch";
@@ -293,13 +283,13 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                     return mainEntries[0];
                 } else if (mainEntries.length > 1) {
                     return this.showMainClassQuickPick(this.formatMainClassOptions(mainEntries),
-                        `Multiple main classes found in the file '${path.basename(currentFile)}', please select one first.`);
+                        `Please select a main class you want to run.`);
                 }
             }
 
             const hintMessage = currentFile ?
-                `No main class found in the file '${path.basename(currentFile)}', please select main class<project name> again.` :
-                "Please select main class<project name>.";
+                `The file '${path.basename(currentFile)}' is not executable, please select a main class you want to run.` :
+                "Please select a main class you want to run.";
             return this.promptMainClass(folder, hintMessage);
         }
 

--- a/src/debugCodeLensProvider.ts
+++ b/src/debugCodeLensProvider.ts
@@ -173,7 +173,7 @@ async function launchJsonExists(workspace: vscode.Uri): Promise<boolean> {
 
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(workspace);
     const results: vscode.Uri[] = await vscode.workspace.findFiles(".vscode/launch.json");
-    return !!results.find((launchJson => vscode.workspace.getWorkspaceFolder(launchJson) == workspaceFolder));
+    return !!results.find((launchJson) => vscode.workspace.getWorkspaceFolder(launchJson) === workspaceFolder);
 }
 
 export async function startDebugging(mainClass: string, projectName: string, uri: vscode.Uri, noDebug: boolean): Promise<boolean> {

--- a/src/debugCodeLensProvider.ts
+++ b/src/debugCodeLensProvider.ts
@@ -150,7 +150,7 @@ async function constructDebugConfig(mainClass: string, projectName: string, work
         };
 
         // Persist the configuration into launch.json only if the launch.json file already exists in the workspace.
-        if (workspace && ((rawConfigs && rawConfigs.length) || await launchJsonExists())) {
+        if ((rawConfigs && rawConfigs.length) || await launchJsonExists(workspace)) {
             try {
                 // Insert the default debug configuration to the beginning of launch.json.
                 rawConfigs.splice(0, 0, debugConfig);
@@ -166,9 +166,14 @@ async function constructDebugConfig(mainClass: string, projectName: string, work
     return _.cloneDeep(debugConfig);
 }
 
-async function launchJsonExists(): Promise<boolean> {
-    const results: vscode.Uri[] = await vscode.workspace.findFiles(".vscode/launch.json", null, 1);
-    return !!results.length;
+async function launchJsonExists(workspace: vscode.Uri): Promise<boolean> {
+    if (!workspace) {
+        return false;
+    }
+
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(workspace);
+    const results: vscode.Uri[] = await vscode.workspace.findFiles(".vscode/launch.json");
+    return !!results.find((launchJson => vscode.workspace.getWorkspaceFolder(launchJson) == workspaceFolder));
 }
 
 export async function startDebugging(mainClass: string, projectName: string, uri: vscode.Uri, noDebug: boolean): Promise<boolean> {

--- a/src/debugCodeLensProvider.ts
+++ b/src/debugCodeLensProvider.ts
@@ -149,8 +149,8 @@ async function constructDebugConfig(mainClass: string, projectName: string, work
             projectName,
         };
 
-        // Persist the default debug configuration only if the workspace exists.
-        if (workspace) {
+        // Persist the configuration into launch.json only if the launch.json file already exists in the workspace.
+        if (workspace && ((rawConfigs && rawConfigs.length) || await launchJsonExists())) {
             try {
                 // Insert the default debug configuration to the beginning of launch.json.
                 rawConfigs.splice(0, 0, debugConfig);
@@ -164,6 +164,11 @@ async function constructDebugConfig(mainClass: string, projectName: string, work
     }
 
     return _.cloneDeep(debugConfig);
+}
+
+async function launchJsonExists(): Promise<boolean> {
+    const results: vscode.Uri[] = await vscode.workspace.findFiles(".vscode/launch.json", null, 1);
+    return !!results.length;
 }
 
 export async function startDebugging(mainClass: string, projectName: string, uri: vscode.Uri, noDebug: boolean): Promise<boolean> {


### PR DESCRIPTION
Signed-off-by: Jinbo Wang <jinbwan@microsoft.com>

Fix #724

- No launch.json in the current workspace.
Triggering run or debug from the entries, such as **F5**, **Code Lens** and **Context Menu**, will generate a java configuration in memory and run the program directly.

- launch.json already exists in the current workspace.
Trigger from **Code Lens** or **Context Menu** will also persist the configuration into the launch.json.

