### PR TITLE
Added debugger user setting for setting numeric precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Please also check the documentation of [Language Support for Java by Red Hat](ht
 - `java.debug.settings.showLogicalStructure`: show the logical structure for the Collection and Map classes in "Variables" viewlet, defaults to `true`.
 - `java.debug.settings.showToString`: show 'toString()' value for all classes that override 'toString' method in "Variables" viewlet, defaults to `true`.
 - `java.debug.settings.maxStringLength`: the maximum length of string displayed in "Variables" or "Debug Console" viewlet, the string longer than this length will be trimmed, defaults to `0` which means no trim is performed.
+- `java.debug.settings.numericPrecision`: the precision when formatting doubles in "Variables" or "Debug Console" viewlet.
 - `java.debug.settings.hotCodeReplace`: Reload the changed Java classes during debugging, defaults to `manual`. Make sure `java.autobuild.enabled` is not disabled for [VSCode Java](https://github.com/redhat-developer/vscode-java). See the [wiki page](https://github.com/Microsoft/vscode-java-debug/wiki/Hot-Code-Replace) for more information about usages and limitations.
   - manual - Click the toolbar to apply the changes.
   - auto - Automatically apply the changes after compilation.

--- a/package.json
+++ b/package.json
@@ -480,6 +480,11 @@
           "description": "%java.debugger.configuration.maxStringLength.description%",
           "default": 0
         },
+        "java.debug.settings.numericPrecision": {
+          "type": "number",
+          "description": "%java.debugger.configuration.numericPrecision.description%",
+          "default": 0
+        },
         "java.debug.settings.hotCodeReplace": {
           "type": "string",
           "default": "manual",

--- a/package.nls.json
+++ b/package.nls.json
@@ -42,6 +42,7 @@
     "java.debugger.configuration.showLogicalStructure.description": "Show the logical structure for the Collection and Map classes in \"Variables\" viewlet.",
     "java.debugger.configuration.showToString.description": "Show 'toString()' value for all classes that override 'toString' method in \"Variables\" viewlet.",
     "java.debugger.configuration.maxStringLength.description": "The maximum length of strings displayed in \"Variables\" or \"Debug Console\" viewlet, strings longer than this length will be trimmed, if 0 no trim is performed.",
+    "java.debugger.configuration.numericPrecision.description": "The precision when formatting doubles in \"Variables\" or \"Debug Console\" viewlet.",
     "java.debugger.configuration.hotCodeReplace.description": "Reload the changed Java classes during debugging. Make sure 'java.autobuild.enabled' is not disabled.",
     "java.debugger.configuration.enableRunDebugCodeLens.description": "Enable the run and debug code lens providers over main methods.",
     "java.debugger.configuration.forceBuildBeforeLaunch": "Force building the workspace before launching java program.",


### PR DESCRIPTION
Fixes [microsoft/vscode-java-debug#745](https://github.com/microsoft/vscode-java-debug/issues/745#issue-547078106)

Requires [microsoft/java-debug/pull#313](https://github.com/microsoft/java-debug/pull/313)