### PR TITLE
activate before execute java extension commands

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -32,7 +32,7 @@ export async function buildWorkspace(): Promise<boolean> {
 }
 
 async function handleBuildFailure(operationId: string, err: any): Promise<boolean> {
-    if (err instanceof utility.JavaExtensionNotActivatedError) {
+    if (err instanceof utility.JavaExtensionNotEnabledError) {
         utility.guideToInstallJavaExtension();
         return false;
     }

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -46,7 +46,7 @@ export async function executeJavaExtensionCommand(commandName: string, ...rest) 
     // TODO: need to handle error and trace telemetry
     const javaExtension = utility.getJavaExtension();
     if (!javaExtension) {
-        throw new utility.JavaExtensionNotActivatedError(`Cannot execute command ${commandName}, VS Code Java Extension is not enabled.`);
+        throw new utility.JavaExtensionNotEnabledError(`Cannot execute command ${commandName}, VS Code Java Extension is not enabled.`);
     }
     if (!javaExtension.isActive) {
         await javaExtension.activate();

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -39,17 +39,17 @@ export const JAVA_IS_ON_CLASSPATH = "vscode.java.isOnClasspath";
 export const JAVA_RESOLVE_JAVAEXECUTABLE = "vscode.java.resolveJavaExecutable";
 
 export function executeJavaLanguageServerCommand(...rest) {
-    // TODO: need to handle error and trace telemetry
-    if (!utility.isJavaExtEnabled()) {
-        throw new utility.JavaExtensionNotActivatedError(
-            `Cannot execute command ${JAVA_EXECUTE_WORKSPACE_COMMAND}, VS Code Java Extension is not enabled.`);
-    }
-    return vscode.commands.executeCommand(JAVA_EXECUTE_WORKSPACE_COMMAND, ...rest);
+    return executeJavaExtensionCommand(JAVA_EXECUTE_WORKSPACE_COMMAND, ...rest);
 }
 
-export function executeJavaExtensionCommand(commandName: string, ...rest) {
-    if (!utility.isJavaExtEnabled()) {
+export async function executeJavaExtensionCommand(commandName: string, ...rest) {
+    // TODO: need to handle error and trace telemetry
+    const javaExtension = utility.getJavaExtension();
+    if (!javaExtension) {
         throw new utility.JavaExtensionNotActivatedError(`Cannot execute command ${commandName}, VS Code Java Extension is not enabled.`);
+    }
+    if (!javaExtension.isActive) {
+        await javaExtension.activate();
     }
     return vscode.commands.executeCommand(commandName, ...rest);
 }

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -83,7 +83,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                     });
                     resolve([defaultLaunchConfig, ...launchConfigs]);
                 } catch (ex) {
-                    if (ex instanceof utility.JavaExtensionNotActivatedError) {
+                    if (ex instanceof utility.JavaExtensionNotEnabledError) {
                         utility.guideToInstallJavaExtension();
                     }
                     p.report({ message: `failed to generate configuration. ${ex}` });
@@ -232,7 +232,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                 throw new Error("Failed to start debug server.");
             }
         } catch (ex) {
-            if (ex instanceof utility.JavaExtensionNotActivatedError) {
+            if (ex instanceof utility.JavaExtensionNotEnabledError) {
                 utility.guideToInstallJavaExtension();
                 return undefined;
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -178,7 +178,7 @@ async function runJavaFile(uri: vscode.Uri, noDebug: boolean) {
         // Wait for Java Language Support extension being activated.
         await utility.getJavaExtensionAPI();
     } catch (ex) {
-        if (ex instanceof utility.JavaExtensionNotActivatedError) {
+        if (ex instanceof utility.JavaExtensionNotEnabledError) {
             utility.guideToInstallJavaExtension();
             return;
         }

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -21,7 +21,7 @@ export class UserError extends Error {
     }
 }
 
-export class JavaExtensionNotActivatedError extends Error {
+export class JavaExtensionNotEnabledError extends Error {
     constructor(message) {
         super(message);
         setUserError(this);
@@ -154,7 +154,7 @@ export async function getJavaHome(): Promise<string> {
 export function getJavaExtensionAPI(): Thenable<any> {
     const extension = vscode.extensions.getExtension(JAVA_EXTENSION_ID);
     if (!extension) {
-        throw new JavaExtensionNotActivatedError("VS Code Java Extension is not enabled.");
+        throw new JavaExtensionNotEnabledError("VS Code Java Extension is not enabled.");
     }
 
     return extension.activate();

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -160,6 +160,10 @@ export function getJavaExtensionAPI(): Thenable<any> {
     return extension.activate();
 }
 
+export function getJavaExtension(): vscode.Extension<any> {
+    return vscode.extensions.getExtension(JAVA_EXTENSION_ID);
+}
+
 export function isJavaExtEnabled(): boolean {
     const javaExt = vscode.extensions.getExtension(JAVA_EXTENSION_ID);
     return !!javaExt;


### PR DESCRIPTION
`command 'java.execute.workspaceCommand' not found` reported by users when run/debug projects.

my guess is, while language server was being activated, debugger tried executing the command, which was not ready. 