### PR TITLE
Make the run buttons in editor toolbar more context-aware

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -268,12 +268,7 @@ async function runJavaFile(uri: vscode.Uri, noDebug: boolean) {
     const canRunTests: boolean = await canDelegateToJavaTestRunner(uri);
 
     if (!hasMainMethods && !canRunTests) {
-        const workspaceFolder: vscode.WorkspaceFolder | undefined = vscode.workspace.getWorkspaceFolder(uri);
-        if (!workspaceFolder) {
-            vscode.window.showErrorMessage(`Failed to run the project because the file: ${uri.fsPath} does not belongs to the current workspace.`);
-            return;
-        }
-        const mainClasses: IMainClassOption[] = await utility.searchMainMethods(workspaceFolder.uri);
+        const mainClasses: IMainClassOption[] = await utility.searchMainMethods();
         await launchMain(mainClasses, uri, noDebug);
     } else if (hasMainMethods && !canRunTests) {
         await launchMain(mainMethods, uri, noDebug);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -309,7 +309,7 @@ async function launchMain(mainMethods: IMainClassOption[], uri: vscode.Uri, noDe
         return;
     }
 
-    const pick = await mainClassPicker.showQuickPick(mainMethods, "Select the main class to run.", (option) => option.mainClass);
+    const pick = await mainClassPicker.showQuickPickWithRecentlyUsed(mainMethods, "Select the main class to run.");
     if (!pick) {
         return;
     }
@@ -334,7 +334,7 @@ async function runJavaProject(node: any, noDebug: boolean) {
     }
 
     const pick = await mainClassPicker.showQuickPickWithRecentlyUsed(mainClassesOptions,
-        "Select the main class to run.", (option) => option.mainClass);
+        "Select the main class to run.");
     if (!pick) {
         return;
     }

--- a/src/mainClassPicker.ts
+++ b/src/mainClassPicker.ts
@@ -7,7 +7,7 @@ import { TextEditor, window } from "vscode";
 import { IMainClassOption } from "./languageServerPlugin";
 
 const defaultLabelFormatter = (option: IMainClassOption) => {
-    return option.mainClass + `${option.projectName ? "<" + option.projectName + ">" : ""}`;
+    return option.mainClass;
 };
 type Formatter = (option: IMainClassOption) => string;
 
@@ -44,7 +44,7 @@ class MainClassPicker {
             return {
                 label: labelFormatter(option),
                 description: option.filePath ? path.basename(option.filePath) : "",
-                detail: undefined,
+                detail: option.projectName ? `Project: ${option.projectName}` : "",
                 data: option,
             };
         });
@@ -107,6 +107,10 @@ class MainClassPicker {
 
             if (isFromActiveEditor(option)) {
                 adjustedDetail.push(`$(file-text) active editor (${path.basename(option.filePath)})`);
+            }
+
+            if (option.projectName) {
+                adjustedDetail.push(`Project: ${option.projectName}`);
             }
 
             const detail: string = adjustedDetail.join(", ");

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -251,20 +251,13 @@ export async function waitForStandardMode(): Promise<boolean> {
     return true;
 }
 
-export async function searchMainMethods(...uris: vscode.Uri[] | undefined): Promise<IMainClassOption[]> {
+export async function searchMainMethods(uri?: vscode.Uri): Promise<IMainClassOption[]> {
     try {
         return await vscode.window.withProgress<IMainClassOption[]>(
             { location: vscode.ProgressLocation.Window },
             async (p) => {
                 p.report({ message: "Searching main classes..." });
-                if (_.isEmpty(uris)) {
-                    uris = vscode.workspace.workspaceFolders.map((folder) => folder.uri);
-                }
-                const mainClasses: IMainClassOption[] = [];
-                for (const uri of uris) {
-                    mainClasses.push(...await resolveMainClass(uri));
-                }
-                return mainClasses;
+                return resolveMainClass(uri);
             });
     } catch (ex) {
         vscode.window.showErrorMessage(String((ex && ex.message) || ex));

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -250,7 +250,7 @@ export async function waitForStandardMode(): Promise<boolean> {
     return true;
 }
 
-export async function searchMainMethods(uri: vscode.Uri): Promise<IMainClassOption> {
+export async function searchMainMethods(uri: vscode.Uri): Promise<IMainClassOption[]> {
     try {
         return await vscode.window.withProgress<IMainClassOption[]>(
             {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as _ from "lodash";
 import * as path from "path";
 import * as vscode from "vscode";
 import { sendError, sendInfo, setUserError } from "vscode-extension-telemetry-wrapper";

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -4,6 +4,7 @@
 import * as path from "path";
 import * as vscode from "vscode";
 import { sendError, sendInfo, setUserError } from "vscode-extension-telemetry-wrapper";
+import { IMainClassOption, resolveMainClass } from "./languageServerPlugin";
 import { logger, Type } from "./logger";
 
 const TROUBLESHOOTING_LINK = "https://github.com/Microsoft/vscode-java-debug/blob/master/Troubleshooting.md";
@@ -247,4 +248,22 @@ export async function waitForStandardMode(): Promise<boolean> {
     }
 
     return true;
+}
+
+export async function searchMainMethods(uri: vscode.Uri): Promise<IMainClassOption> {
+    try {
+        return await vscode.window.withProgress<IMainClassOption[]>(
+            {
+                location: vscode.ProgressLocation.Window,
+            },
+            async (p) => {
+                p.report({
+                    message: "Searching main class...",
+                });
+                return resolveMainClass(uri);
+            });
+    } catch (ex) {
+        vscode.window.showErrorMessage(String((ex && ex.message) || ex));
+        throw ex;
+    }
 }


### PR DESCRIPTION
- If the file has a main() method, run it
- If the file is a test file, delegate to Test Runner
- If neither has a main() method nor is a test file, try to launch as a project
- If both has a main() method and is a test file, let the user to choose

Signed-off-by: Sheng Chen <sheche@microsoft.com>