### PR TITLE
Update the group name registration in Java Projects explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,12 +104,12 @@
         {
           "command": "java.debug.runFromProjectView",
           "when": "view == javaProjectExplorer && viewItem =~ /java:project(?=.*?\\b\\+java\\b)(?=.*?\\b\\+uri\\b)/",
-          "group": "debugger@1"
+          "group": "8_execution@10"
         },
         {
           "command": "java.debug.debugFromProjectView",
           "when": "view == javaProjectExplorer && viewItem =~ /java:project(?=.*?\\b\\+java\\b)(?=.*?\\b\\+uri\\b)/",
-          "group": "debugger@2"
+          "group": "8_execution@20"
         }
       ],
       "explorer/context": [


### PR DESCRIPTION
Update the group name according to: https://github.com/microsoft/vscode-java-dependency/wiki/Register-Command-onto-the-Nodes-of-Project-View#sorting-of-groups

Signed-off-by: Sheng Chen <sheche@microsoft.com>