### PR TITLE
Enable unused/implicit checks in tsconfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,10 +30,26 @@
             "integrity": "sha512-mQjDxyOM1Cpocd+vm1kZBP7smwKZ4TNokFeds9LV7OZibmPJFEzY3+xZMrKfUdNT71lv8GoCPD6upKwHxubClw==",
             "dev": true
         },
+        "@types/glob": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+            "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
+            "dev": true,
+            "requires": {
+                "@types/minimatch": "*",
+                "@types/node": "*"
+            }
+        },
         "@types/lodash": {
             "version": "4.14.137",
             "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.137.tgz",
             "integrity": "sha512-g4rNK5SRKloO+sUGbuO7aPtwbwzMgjK+bm9BBhLD7jGUiGR7zhwYEhSln/ihgYQBeIJ5j7xjyaYzrWTcu3UotQ==",
+            "dev": true
+        },
+        "@types/minimatch": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
             "dev": true
         },
         "@types/mocha": {

--- a/package.json
+++ b/package.json
@@ -753,6 +753,7 @@
     "test": "npm run compile && node ./out/test/index.js"
   },
   "devDependencies": {
+    "@types/glob": "^7.1.3",
     "@types/lodash": "^4.14.137",
     "@types/mocha": "^5.2.7",
     "@types/node": "^8.10.51",

--- a/src/build.ts
+++ b/src/build.ts
@@ -86,7 +86,7 @@ function checkErrorsReportedByJavaExtension(): boolean {
 }
 
 async function showFixSuggestions(operationId: string) {
-    let buildFiles = [];
+    let buildFiles: string[] = [];
     try {
         buildFiles = await lsPlugin.resolveBuildFiles();
     } catch (error) {

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -44,11 +44,11 @@ export const JAVA_RESOLVE_CLASSFILTERS = "vscode.java.resolveClassFilters";
 
 export const JAVA_RESOLVE_SOURCE_URI = "vscode.java.resolveSourceUri";
 
-export function executeJavaLanguageServerCommand(...rest) {
+export function executeJavaLanguageServerCommand(...rest: any[]) {
     return executeJavaExtensionCommand(JAVA_EXECUTE_WORKSPACE_COMMAND, ...rest);
 }
 
-export async function executeJavaExtensionCommand(commandName: string, ...rest) {
+export async function executeJavaExtensionCommand(commandName: string, ...rest: any[]) {
     // TODO: need to handle error and trace telemetry
     const javaExtension = utility.getJavaExtension();
     if (!javaExtension) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { initializeCodeLensProvider, startDebugging } from "./debugCodeLensProvi
 import { handleHotCodeReplaceCustomEvent, initializeHotCodeReplace, NO_BUTTON, YES_BUTTON } from "./hotCodeReplace";
 import { JavaDebugAdapterDescriptorFactory } from "./javaDebugAdapterDescriptorFactory";
 import { logJavaException, logJavaInfo } from "./javaLogger";
-import { IMainClassOption, IMainMethod, resolveMainClass, resolveMainMethod } from "./languageServerPlugin";
+import { IMainClassOption, IMainMethod, resolveMainMethod } from "./languageServerPlugin";
 import { logger, Type } from "./logger";
 import { mainClassPicker  } from "./mainClassPicker";
 import { pickJavaProcess } from "./processPicker";
@@ -29,7 +29,7 @@ export async function activate(context: vscode.ExtensionContext) {
     await instrumentOperation("activation", initializeExtension)(context);
 }
 
-function initializeExtension(operationId: string, context: vscode.ExtensionContext) {
+function initializeExtension(_operationId: string, context: vscode.ExtensionContext) {
     // Deprecated
     logger.initialize(context, true);
 
@@ -123,7 +123,7 @@ function registerDebugEventListener(context: vscode.ExtensionContext) {
     }));
 }
 
-function handleUserNotification(customEvent) {
+function handleUserNotification(customEvent: vscode.DebugSessionCustomEvent) {
     if (customEvent.body.notificationType === "ERROR") {
         utility.showErrorMessageWithTroubleshooting({
             message: customEvent.body.message,

--- a/src/hotCodeReplace.ts
+++ b/src/hotCodeReplace.ts
@@ -38,7 +38,7 @@ export function initializeHotCodeReplace(context: vscode.ExtensionContext) {
     }));
 }
 
-export function handleHotCodeReplaceCustomEvent(hcrEvent) {
+export function handleHotCodeReplaceCustomEvent(hcrEvent: vscode.DebugSessionCustomEvent) {
     if (hcrEvent.body.changeType === HcrChangeType.BUILD_COMPLETE) {
         if (getHotReloadFlag() === "auto") {
             return vscode.window.withProgress({ location: vscode.ProgressLocation.Window }, (progress) => {
@@ -62,6 +62,7 @@ export function handleHotCodeReplaceCustomEvent(hcrEvent) {
             });
         }
     }
+    return undefined;
 }
 
 function getHotReloadFlag(): string {

--- a/src/hoverProvider.ts
+++ b/src/hoverProvider.ts
@@ -43,10 +43,10 @@ class DebugHoverProvider implements Disposable {
 }
 
 class InternalDebugHoverProvider implements HoverProvider {
-    public provideHover(document: TextDocument, position: Position, token: CancellationToken): ProviderResult<Hover> {
+    public provideHover(document: TextDocument, position: Position, _token: CancellationToken): ProviderResult<Hover> {
         const range = document.getWordRangeAtPosition(position, /\w+/);
         if (!range || document.getText(range) !== "main") {
-            return;
+            return undefined;
         }
 
         const line = document.lineAt(position);
@@ -69,6 +69,8 @@ class InternalDebugHoverProvider implements HoverProvider {
             contributed.isTrusted = true;
             return new Hover(contributed);
         }
+
+        return undefined;
     }
 
     private isMainMethod(line: string): boolean {

--- a/src/javaDebugAdapterDescriptorFactory.ts
+++ b/src/javaDebugAdapterDescriptorFactory.ts
@@ -8,8 +8,8 @@ import { Type } from "./logger";
 import { convertErrorToMessage, showErrorMessageWithTroubleshooting } from "./utility";
 
 export class JavaDebugAdapterDescriptorFactory implements DebugAdapterDescriptorFactory {
-    public async createDebugAdapterDescriptor(session: DebugSession, executable: DebugAdapterExecutable): Promise<DebugAdapterDescriptor> {
-        let error;
+    public async createDebugAdapterDescriptor(_session: DebugSession, _executable: DebugAdapterExecutable): Promise<DebugAdapterDescriptor> {
+        let error: Error;
         try {
             const debugServerPort = <number> (await startDebugSession());
             if (debugServerPort) {
@@ -28,5 +28,6 @@ export class JavaDebugAdapterDescriptorFactory implements DebugAdapterDescriptor
             message: "Failed to start debug server.",
         };
         showErrorMessageWithTroubleshooting(message);
+        return undefined;
     }
 }

--- a/src/javaLogger.ts
+++ b/src/javaLogger.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { sendError, sendInfo, sendOperationError } from "vscode-extension-telemetry-wrapper";
+import { sendInfo, sendOperationError } from "vscode-extension-telemetry-wrapper";
 
 export function logJavaException(errorProperties: any): void {
     /**

--- a/src/languageServerPlugin.ts
+++ b/src/languageServerPlugin.ts
@@ -45,7 +45,7 @@ export function startDebugSession() {
     return commands.executeJavaLanguageServerCommand(commands.JAVA_START_DEBUGSESSION);
 }
 
-export function resolveClasspath(mainClass, projectName) {
+export function resolveClasspath(mainClass: string, projectName: string) {
     return commands.executeJavaLanguageServerCommand(commands.JAVA_RESOLVE_CLASSPATH, mainClass, projectName);
 }
 
@@ -101,7 +101,7 @@ export async function isOnClasspath(uri: string): Promise<boolean> {
     }
 }
 
-export function resolveJavaExecutable(mainClass, projectName) {
+export function resolveJavaExecutable(mainClass: string, projectName: string) {
     return commands.executeJavaLanguageServerCommand(commands.JAVA_RESOLVE_JAVAEXECUTABLE, mainClass, projectName);
 }
 

--- a/src/launchCommand.ts
+++ b/src/launchCommand.ts
@@ -60,8 +60,8 @@ export async function addMoreHelpfulVMArgs(config: vscode.DebugConfiguration) {
 }
 
 function checkJavaVersion(javaExec: string): Promise<number> {
-    return new Promise((resolve, reject) => {
-        cp.execFile(javaExec, ["-version"], {}, (error, stdout, stderr) => {
+    return new Promise((resolve, _reject) => {
+        cp.execFile(javaExec, ["-version"], {}, (_error, _stdout, stderr) => {
             const javaVersion = parseMajorVersion(stderr);
             resolve(javaVersion);
         });

--- a/src/mainClassPicker.ts
+++ b/src/mainClassPicker.ts
@@ -35,7 +35,7 @@ class MainClassPicker {
         }
 
         if (!options || !options.length) {
-            return;
+            return undefined;
         } else if (autoPick && options.length === 1) {
             return options[0];
         }
@@ -53,6 +53,7 @@ class MainClassPicker {
         if (selected) {
             return selected.data;
         }
+        return undefined;
     }
 
     // tslint:disable-next-line
@@ -77,7 +78,7 @@ class MainClassPicker {
         }
 
         if (!options || !options.length) {
-            return;
+            return undefined;
         } else if (autoPick && options.length === 1) {
             return options[0];
         }
@@ -146,6 +147,7 @@ class MainClassPicker {
             this.updateMRUTimestamp(selected.data);
             return selected.data;
         }
+        return undefined;
     }
 
     private getMRUTimestamp(mainClassOption: IMainClassOption): number {

--- a/src/processPicker.ts
+++ b/src/processPicker.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT license.
 
 import * as path from "path";
-import { DebugConfiguration, window } from "vscode";
+import { window } from "vscode";
 import { getProcesses, getProcessTree } from "./processTree";
 
 const JAVA_PATTERN = /(?:java|javaw|j9|j9w)$/i;
@@ -42,12 +42,14 @@ function convertToJavaProcess(pid: number, command: string, args: string): IJava
             };
         }
     }
+
+    return undefined;
 }
 
 export async function pickJavaProcess(): Promise<IJavaProcess> {
     const javaProcesses: IJavaProcess[] = [];
     try {
-        await getProcesses((pid: number, ppid: number, command: string, args: string, date: number) => {
+        await getProcesses((pid: number, _ppid: number, command: string, args: string, _date: number) => {
             const javaProcess = convertToJavaProcess(pid, command, args);
             if (javaProcess) {
                 javaProcesses.push(javaProcess);
@@ -79,6 +81,8 @@ export async function pickJavaProcess(): Promise<IJavaProcess> {
     if (pick) {
         return pick.process;
     }
+
+    return undefined;
 }
 
 export async function resolveJavaProcess(pid: number): Promise<IJavaProcess | undefined> {

--- a/src/terminalLinkProvider.ts
+++ b/src/terminalLinkProvider.ts
@@ -14,7 +14,7 @@ export class JavaTerminalLinkProvder implements TerminalLinkProvider<IJavaTermin
      * @param token A cancellation token.
      * @return A list of terminal links for the given line.
      */
-    public provideTerminalLinks(context: TerminalLinkContext, token: CancellationToken): ProviderResult<IJavaTerminalLink[]> {
+    public provideTerminalLinks(context: TerminalLinkContext, _token: CancellationToken): ProviderResult<IJavaTerminalLink[]> {
         if (context.terminal.name !== "Java Debug Console" && context.terminal.name !== "Java Process Console") {
             return [];
         }
@@ -32,6 +32,8 @@ export class JavaTerminalLinkProvder implements TerminalLinkProvider<IJavaTermin
                 lineNumber: sourceLineNumber,
             }];
         }
+
+        return [];
     }
 
     /**

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -23,7 +23,7 @@ export class UserError extends Error {
 }
 
 export class JavaExtensionNotEnabledError extends Error {
-    constructor(message) {
+    constructor(message: string) {
         super(message);
         setUserError(this);
     }
@@ -95,7 +95,7 @@ export async function showErrorMessageWithTroubleshooting(message: ITroubleshoot
 function handleTroubleshooting(choice: string, message: string, anchor: string): string | undefined {
     if (choice === LEARN_MORE) {
         openTroubleshootingPage(message, anchor);
-        return;
+        return undefined;
     }
 
     return choice;

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -12,7 +12,7 @@ suite("Extension Tests", () => {
 
     test("should activate", function() {
         this.timeout(1 * 60 * 1000);
-        return vscode.extensions.getExtension("vscjava.vscode-java-debug").activate().then((api) => {
+        return vscode.extensions.getExtension("vscjava.vscode-java-debug").activate().then((_api) => {
             assert.ok(true);
         });
     });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,12 +3,17 @@
         "module": "commonjs",
         "target": "es6",
         "outDir": "out",
-        "alwaysStrict": true,
         "lib": [
             "es6"
         ],
         "sourceMap": true,
-        "rootDir": "."
+        "rootDir": ".",
+        "noUnusedLocals": true,
+        "noImplicitThis": true,
+        "noImplicitAny": true,
+        "noImplicitReturns": true,
+        "noUnusedParameters": true,
+        "alwaysStrict": true
     },
     "exclude": [
         "node_modules",


### PR DESCRIPTION
This PR enabled TS compiler check for:

- Unused import/local variables
- Unused function parameters
- Implicit this/any/return

Also fixed existing errors.