### PR TITLE
Use a progress reporter to hint the current build status when run or debug a program

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Please also check the documentation of [Language Support for Java by Red Hat](ht
 - `java.debug.settings.jdwp.limitOfVariablesPerJdwpRequest`: The maximum number of variables or fields that can be requested in one JDWP request. The higher the value, the less frequently debuggee will be requested when expanding the variable view. Also a large number can cause JDWP request timeout. Defaults to 100.
 - `java.debug.settings.jdwp.requestTimeout`: The timeout (ms) of JDWP request when the debugger communicates with the target JVM. Defaults to 3000.
 - `java.debug.settings.vmArgs`: The default VM arguments to launch the Java program. Eg. Use '-Xmx1G -ea' to increase the heap size to 1GB and enable assertions. If you want to customize the VM arguments for a specific debug session, please modify the 'vmArgs' config in launch.json.
-- `java.silentNotification`: Control whether the progress notifications can be shown. Defaults to `false`.
+- `java.silentNotification`: Controls whether notifications can be used to report progress. If true, use status bar to report progress instead. Defaults to `false`.
 
 Pro Tip: The documentation [Configuration.md](https://github.com/microsoft/vscode-java-debug/blob/master/Configuration.md) provides lots of samples to demonstrate how to use these debug configurations, recommend to take a look.
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Please also check the documentation of [Language Support for Java by Red Hat](ht
 - `java.debug.settings.jdwp.limitOfVariablesPerJdwpRequest`: The maximum number of variables or fields that can be requested in one JDWP request. The higher the value, the less frequently debuggee will be requested when expanding the variable view. Also a large number can cause JDWP request timeout. Defaults to 100.
 - `java.debug.settings.jdwp.requestTimeout`: The timeout (ms) of JDWP request when the debugger communicates with the target JVM. Defaults to 3000.
 - `java.debug.settings.vmArgs`: The default VM arguments to launch the Java program. Eg. Use '-Xmx1G -ea' to increase the heap size to 1GB and enable assertions. If you want to customize the VM arguments for a specific debug session, please modify the 'vmArgs' config in launch.json.
-- `java.debug.settings.showRunStatusAsNotification`: Show the build status as the progress notification every time you run or debug a program. Defaults to `true`.
+- `java.silentNotification`: Control whether the progress notifications can be shown. Defaults to `false`.
 
 Pro Tip: The documentation [Configuration.md](https://github.com/microsoft/vscode-java-debug/blob/master/Configuration.md) provides lots of samples to demonstrate how to use these debug configurations, recommend to take a look.
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ Please also check the documentation of [Language Support for Java by Red Hat](ht
 - `java.debug.settings.jdwp.limitOfVariablesPerJdwpRequest`: The maximum number of variables or fields that can be requested in one JDWP request. The higher the value, the less frequently debuggee will be requested when expanding the variable view. Also a large number can cause JDWP request timeout. Defaults to 100.
 - `java.debug.settings.jdwp.requestTimeout`: The timeout (ms) of JDWP request when the debugger communicates with the target JVM. Defaults to 3000.
 - `java.debug.settings.vmArgs`: The default VM arguments to launch the Java program. Eg. Use '-Xmx1G -ea' to increase the heap size to 1GB and enable assertions. If you want to customize the VM arguments for a specific debug session, please modify the 'vmArgs' config in launch.json.
+- `java.debug.settings.showRunStatusAsNotification`: Show the build status as the progress notification every time you run or debug a program. Defaults to `true`.
 
 Pro Tip: The documentation [Configuration.md](https://github.com/microsoft/vscode-java-debug/blob/master/Configuration.md) provides lots of samples to demonstrate how to use these debug configurations, recommend to take a look.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -59,9 +59,15 @@
             "dev": true
         },
         "@types/node": {
-            "version": "8.10.51",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.51.tgz",
-            "integrity": "sha512-cArrlJp3Yv6IyFT/DYe+rlO8o3SIHraALbBW/+CcCYW/a9QucpLI+n2p4sRxAvl2O35TiecpX2heSZtJjvEO+Q==",
+            "version": "14.14.10",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.10.tgz",
+            "integrity": "sha512-J32dgx2hw8vXrSbu4ZlVhn1Nm3GbeCFNw2FWL8S5QKucHGY0cyNwjdQdO+KMBZ4wpmC7KhLCiNsdk1RFRIYUQQ==",
+            "dev": true
+        },
+        "@types/uuid": {
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.0.tgz",
+            "integrity": "sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==",
             "dev": true
         },
         "@types/vscode": {
@@ -1134,6 +1140,11 @@
             "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
             "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
             "dev": true
+        },
+        "compare-versions": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
+            "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA=="
         },
         "component-emitter": {
             "version": "1.3.0",
@@ -5797,9 +5808,9 @@
             "dev": true
         },
         "typescript": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-            "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==",
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.2.tgz",
+            "integrity": "sha512-thGloWsGH3SOxv1SoY7QojKi0tc+8FnOmiarEGMbd/lar7QOEd3hvlx3Fp5y6FlDUGl9L+pd4n2e+oToGMmhRQ==",
             "dev": true
         },
         "unc-path-regex": {
@@ -5973,9 +5984,9 @@
             "dev": true
         },
         "uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+            "version": "8.3.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+            "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
         },
         "v8-compile-cache": {
             "version": "2.0.3",
@@ -6083,6 +6094,13 @@
             "requires": {
                 "uuid": "^3.4.0",
                 "vscode-extension-telemetry": "^0.1.6"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "3.4.0",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+                    "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+                }
             }
         },
         "vscode-test": {

--- a/package.json
+++ b/package.json
@@ -741,6 +741,11 @@
           "type": "string",
           "description": "%java.debugger.configuration.vmArgs.description%",
           "default": ""
+        },
+        "java.debug.settings.showRunStatusAsNotification": {
+          "type": "boolean",
+          "description": "%java.debugger.configuration.showRunStatusAsNotification%",
+          "default": true
         }
       }
     }
@@ -756,7 +761,8 @@
     "@types/glob": "^7.1.3",
     "@types/lodash": "^4.14.137",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^8.10.51",
+    "@types/node": "^14.14.10",
+    "@types/uuid": "^8.3.0",
     "@types/vscode": "1.49.0",
     "cross-env": "^5.2.0",
     "gulp": "^4.0.2",
@@ -765,13 +771,15 @@
     "shelljs": "^0.8.3",
     "ts-loader": "^5.4.5",
     "tslint": "^5.18.0",
-    "typescript": "^3.5.3",
+    "typescript": "^4.1.2",
     "vscode-test": "^1.2.0",
     "webpack": "^4.39.2",
     "webpack-cli": "^3.3.7"
   },
   "dependencies": {
+    "compare-versions": "^3.6.0",
     "lodash": "^4.17.19",
+    "uuid": "^8.3.1",
     "vscode-extension-telemetry": "^0.1.6",
     "vscode-extension-telemetry-wrapper": "^0.8.0"
   }

--- a/package.json
+++ b/package.json
@@ -742,10 +742,10 @@
           "description": "%java.debugger.configuration.vmArgs.description%",
           "default": ""
         },
-        "java.debug.settings.showRunStatusAsNotification": {
+        "java.silentNotification": {
           "type": "boolean",
-          "description": "%java.debugger.configuration.showRunStatusAsNotification%",
-          "default": true
+          "description": "%java.debugger.configuration.silentNotification%",
+          "default": false
         }
       }
     }

--- a/package.nls.json
+++ b/package.nls.json
@@ -58,5 +58,6 @@
     "java.debugger.configuration.exceptionBreakpoint.skipClasses": "Skip the specified classes when breaking on exception. You could use the built-in variables such as '$JDK' and '$Libraries' to skip a group of classes, or add a specific class name expression, e.g. java.*, *.Foo",
     "java.debugger.configuration.jdwp.limitOfVariablesPerJdwpRequest.description": "The maximum number of variables or fields that can be requested in one JDWP request. The higher the value, the less frequently debuggee will be requested when expanding the variable view. Also a large number can cause JDWP request timeout.",
     "java.debugger.configuration.jdwp.requestTimeout.description": "The timeout (ms) of JDWP request when the debugger communicates with the target JVM.",
-    "java.debugger.configuration.vmArgs.description": "The default VM arguments to launch the Java program. Eg. Use '-Xmx1G -ea' to increase the heap size to 1GB and enable assertions. If you want to customize the VM arguments for a specific debug session, please modify the 'vmArgs' config in launch.json."
+    "java.debugger.configuration.vmArgs.description": "The default VM arguments to launch the Java program. Eg. Use '-Xmx1G -ea' to increase the heap size to 1GB and enable assertions. If you want to customize the VM arguments for a specific debug session, please modify the 'vmArgs' config in launch.json.",
+    "java.debugger.configuration.showRunStatusAsNotification": "Show the build status as the progress notification every time you run or debug a program."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -59,5 +59,5 @@
     "java.debugger.configuration.jdwp.limitOfVariablesPerJdwpRequest.description": "The maximum number of variables or fields that can be requested in one JDWP request. The higher the value, the less frequently debuggee will be requested when expanding the variable view. Also a large number can cause JDWP request timeout.",
     "java.debugger.configuration.jdwp.requestTimeout.description": "The timeout (ms) of JDWP request when the debugger communicates with the target JVM.",
     "java.debugger.configuration.vmArgs.description": "The default VM arguments to launch the Java program. Eg. Use '-Xmx1G -ea' to increase the heap size to 1GB and enable assertions. If you want to customize the VM arguments for a specific debug session, please modify the 'vmArgs' config in launch.json.",
-    "java.debugger.configuration.silentNotification": "Control whether the progress notifications can be shown."
+    "java.debugger.configuration.silentNotification": "Controls whether notifications can be used to report progress. If true, use status bar to report progress instead."
 }

--- a/package.nls.json
+++ b/package.nls.json
@@ -59,5 +59,5 @@
     "java.debugger.configuration.jdwp.limitOfVariablesPerJdwpRequest.description": "The maximum number of variables or fields that can be requested in one JDWP request. The higher the value, the less frequently debuggee will be requested when expanding the variable view. Also a large number can cause JDWP request timeout.",
     "java.debugger.configuration.jdwp.requestTimeout.description": "The timeout (ms) of JDWP request when the debugger communicates with the target JVM.",
     "java.debugger.configuration.vmArgs.description": "The default VM arguments to launch the Java program. Eg. Use '-Xmx1G -ea' to increase the heap size to 1GB and enable assertions. If you want to customize the VM arguments for a specific debug session, please modify the 'vmArgs' config in launch.json.",
-    "java.debugger.configuration.showRunStatusAsNotification": "Show the build status as the progress notification every time you run or debug a program."
+    "java.debugger.configuration.silentNotification": "Control whether the progress notifications can be shown."
 }

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -57,5 +57,5 @@
     "java.debugger.configuration.jdwp.limitOfVariablesPerJdwpRequest.description": "一次JDWP请求中可以请求的变量或字段的最大数量。该值越高，在展开变量视图时，请求debuggee的频率就越低。同时数量过大也会导致JDWP请求超时。",
     "java.debugger.configuration.jdwp.requestTimeout.description": "调试器与目标JVM通信时JDWP请求的超时时间（ms）。",
     "java.debugger.configuration.vmArgs.description": "启动Java程序的默认VM参数。例如，使用'-Xmx1G -ea'将堆大小增加到1GB并启用断言。如果要为特定的调试会话定制VM参数，请修改launch.json中的'vmArgs'配置。",
-    "java.debugger.configuration.silentNotification": "控制是否可以显示进度通知。"
+    "java.debugger.configuration.silentNotification": "控制是否可以使用通知来报告进度。如果为真，则使用状态栏来报告进度。"
 }

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -57,5 +57,5 @@
     "java.debugger.configuration.jdwp.limitOfVariablesPerJdwpRequest.description": "一次JDWP请求中可以请求的变量或字段的最大数量。该值越高，在展开变量视图时，请求debuggee的频率就越低。同时数量过大也会导致JDWP请求超时。",
     "java.debugger.configuration.jdwp.requestTimeout.description": "调试器与目标JVM通信时JDWP请求的超时时间（ms）。",
     "java.debugger.configuration.vmArgs.description": "启动Java程序的默认VM参数。例如，使用'-Xmx1G -ea'将堆大小增加到1GB并启用断言。如果要为特定的调试会话定制VM参数，请修改launch.json中的'vmArgs'配置。",
-    "java.debugger.configuration.showRunStatusAsNotification": "每次运行或调试程序时，将构建状态显示为进度通知。"
+    "java.debugger.configuration.silentNotification": "控制是否可以显示进度通知。"
 }

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -56,5 +56,6 @@
     "java.debugger.configuration.exceptionBreakpoint.skipClasses": "当发生异常时，跳过指定的类。你可以使用内置变量，如'$JDK'和'$Libraries'来跳过一组类，或者添加一个特定的类名表达式，如java.*，*.Foo。",
     "java.debugger.configuration.jdwp.limitOfVariablesPerJdwpRequest.description": "一次JDWP请求中可以请求的变量或字段的最大数量。该值越高，在展开变量视图时，请求debuggee的频率就越低。同时数量过大也会导致JDWP请求超时。",
     "java.debugger.configuration.jdwp.requestTimeout.description": "调试器与目标JVM通信时JDWP请求的超时时间（ms）。",
-    "java.debugger.configuration.vmArgs.description": "启动Java程序的默认VM参数。例如，使用'-Xmx1G -ea'将堆大小增加到1GB并启用断言。如果要为特定的调试会话定制VM参数，请修改launch.json中的'vmArgs'配置。"
+    "java.debugger.configuration.vmArgs.description": "启动Java程序的默认VM参数。例如，使用'-Xmx1G -ea'将堆大小增加到1GB并启用断言。如果要为特定的调试会话定制VM参数，请修改launch.json中的'vmArgs'配置。",
+    "java.debugger.configuration.showRunStatusAsNotification": "每次运行或调试程序时，将构建状态显示为进度通知。"
 }

--- a/src/build.ts
+++ b/src/build.ts
@@ -38,11 +38,11 @@ export async function buildWorkspace(progressReporter: IProgressReporter): Promi
     if (buildResult.error === CompileWorkspaceStatus.CANCELLED) {
         return false;
     } else {
-        return handleBuildFailure(buildResult.operationId, buildResult.error);
+        return handleBuildFailure(buildResult.operationId, buildResult.error, progressReporter);
     }
 }
 
-async function handleBuildFailure(operationId: string, err: any): Promise<boolean> {
+async function handleBuildFailure(operationId: string, err: any, progressReporter: IProgressReporter): Promise<boolean> {
     const configuration = vscode.workspace.getConfiguration(JAVA_DEBUG_CONFIGURATION);
     const onBuildFailureProceed = configuration.get<boolean>(ON_BUILD_FAILURE_PROCEED);
 
@@ -61,6 +61,9 @@ async function handleBuildFailure(operationId: string, err: any): Promise<boolea
             vscode.commands.executeCommand("workbench.actions.view.problems");
         }
 
+        if (!onBuildFailureProceed) {
+            progressReporter.report("Confirm Build Errors", "Build failed, please select the next action...");
+        }
         const ans = onBuildFailureProceed ? "Proceed" : (await vscode.window.showErrorMessage("Build failed, do you want to continue?",
             "Proceed", "Fix...", "Cancel"));
         sendInfo(operationId, {

--- a/src/build.ts
+++ b/src/build.ts
@@ -35,7 +35,7 @@ export async function buildWorkspace(progressReporter: IProgressReporter): Promi
         };
     })();
 
-    if (buildResult.error === CompileWorkspaceStatus.CANCELLED) {
+    if (progressReporter.isCancelled() || buildResult.error === CompileWorkspaceStatus.CANCELLED) {
         return false;
     } else {
         return handleBuildFailure(buildResult.operationId, buildResult.error, progressReporter);

--- a/src/build.ts
+++ b/src/build.ts
@@ -56,16 +56,13 @@ async function handleBuildFailure(operationId: string, err: any, progressReporte
     });
     setErrorCode(error, Number(err));
     sendOperationError(operationId, "build", error);
-    if (err === lsPlugin.CompileWorkspaceStatus.WITHERROR || err === lsPlugin.CompileWorkspaceStatus.FAILED) {
+    if (!onBuildFailureProceed && (err === lsPlugin.CompileWorkspaceStatus.WITHERROR || err === lsPlugin.CompileWorkspaceStatus.FAILED)) {
         if (checkErrorsReportedByJavaExtension()) {
             vscode.commands.executeCommand("workbench.actions.view.problems");
         }
 
-        if (!onBuildFailureProceed) {
-            progressReporter.report("Confirm Build Errors", "Build failed, please select the next action...");
-        }
-        const ans = onBuildFailureProceed ? "Proceed" : (await vscode.window.showErrorMessage("Build failed, do you want to continue?",
-            "Proceed", "Fix...", "Cancel"));
+        progressReporter.hide(true);
+        const ans = await vscode.window.showErrorMessage("Build failed, do you want to continue?", "Proceed", "Fix...", "Cancel");
         sendInfo(operationId, {
             operationName: "build",
             choiceForBuildError: ans || "esc",

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -175,7 +175,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
         if (!progressReporter && config.__progressId) {
             return undefined;
         } else if (!progressReporter) {
-            progressReporter = progressProvider.createProgressReporter(config.noDebug ? "Run" : "Debug", vscode.ProgressLocation.Notification, true);
+            progressReporter = progressProvider.createProgressReporter(config.noDebug ? "Run" : "Debug");
         }
 
         progressReporter.observe(token);

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -221,8 +221,6 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                     if (!proceed) {
                         return undefined;
                     }
-
-                    progressReporter.show();
                 }
 
                 if (progressReporter.isCancelled()) {
@@ -390,7 +388,9 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
             if (currentFile) {
                 const mainEntries = await lsPlugin.resolveMainMethod(vscode.Uri.file(currentFile));
                 if (mainEntries.length) {
-                    progressReporter.hide(true);
+                    if (!mainClassPicker.isAutoPicked(mainEntries)) {
+                        progressReporter.hide(true);
+                    }
                     return mainClassPicker.showQuickPick(mainEntries, "Please select a main class you want to run.");
                 }
             }
@@ -503,7 +503,9 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
             });
         }
 
-        progressReporter.hide(true);
+        if (!mainClassPicker.isAutoPicked(res)) {
+            progressReporter.hide(true);
+        }
         return mainClassPicker.showQuickPickWithRecentlyUsed(res, hintMessage || "Select main class<project name>");
     }
 }

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -136,7 +136,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
 
                 resolve([defaultLaunchConfig]);
             } finally {
-                progressReporter.cancel();
+                progressReporter.done();
             }
         });
     }

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -110,7 +110,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                     resolve([defaultLaunchConfig]);
                     return;
                 }
-                progressReporter.report("Resolve Java Configs", "Auto generating Java configuration...");
+                progressReporter.report("Generating Java configuration...");
                 const mainClasses = await lsPlugin.resolveMainClass(folder ? folder.uri : undefined);
                 const cache = {};
                 const launchConfigs = mainClasses.map((item) => {
@@ -174,8 +174,10 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
         let progressReporter = progressProvider.getProgressReporter(config.__progressId);
         if (!progressReporter && config.__progressId) {
             return undefined;
+        } else if (!progressReporter) {
+            progressReporter = progressProvider.createProgressReporter(config.noDebug ? "Run" : "Debug", vscode.ProgressLocation.Notification, true);
         }
-        progressReporter = progressReporter || progressProvider.createProgressReporterForPreLaunchTask(config.noDebug ? "Run" : "Debug");
+
         progressReporter.observe(token);
         if (progressReporter.isCancelled()) {
             return undefined;
@@ -216,7 +218,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                 }
 
                 if (needsBuildWorkspace()) {
-                    progressReporter.report("Compile", "Compiling Java workspace...");
+                    progressReporter.report("Compiling...");
                     const proceed = await buildWorkspace(progressReporter);
                     if (!proceed) {
                         return undefined;
@@ -227,9 +229,9 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                     return undefined;
                 }
                 if (!config.mainClass) {
-                    progressReporter.report("Resolve mainClass", "Resolving main class...");
+                    progressReporter.report("Resolving mainClass...");
                 } else {
-                    progressReporter.report("Resolve Configuration", "Resolving launch configuration...");
+                    progressReporter.report("Resolving launch configuration...");
                 }
                 const mainClassOption = await this.resolveAndValidateMainClass(folder && folder.uri, config, progressReporter);
                 if (!mainClassOption || !mainClassOption.mainClass) { // Exit silently if the user cancels the prompt fix by ESC.
@@ -237,7 +239,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                     return undefined;
                 }
 
-                progressReporter.report("Resolve Configuration", "Resolving launch configuration...");
+                progressReporter.report("Resolving launch configuration...");
                 config.mainClass = mainClassOption.mainClass;
                 config.projectName = mainClassOption.projectName;
 

--- a/src/debugCodeLensProvider.ts
+++ b/src/debugCodeLensProvider.ts
@@ -9,6 +9,7 @@ import { instrumentOperationAsVsCodeCommand } from "vscode-extension-telemetry-w
 import { JAVA_LANGID } from "./constants";
 import { initializeHoverProvider } from "./hoverProvider";
 import { IMainMethod, isOnClasspath, resolveMainMethod } from "./languageServerPlugin";
+import { IProgressReporter } from "./progressAPI";
 import { getJavaExtensionAPI, isJavaExtEnabled, ServerMode } from "./utility";
 
 const JAVA_RUN_CODELENS_COMMAND = "java.debug.runCodeLens";
@@ -184,7 +185,8 @@ async function launchJsonExists(workspace?: vscode.Uri): Promise<boolean> {
     return !!results.find((launchJson) => vscode.workspace.getWorkspaceFolder(launchJson) === workspaceFolder);
 }
 
-export async function startDebugging(mainClass: string, projectName: string, uri: vscode.Uri, noDebug: boolean): Promise<boolean> {
+export async function startDebugging(mainClass: string, projectName: string, uri: vscode.Uri, noDebug: boolean,
+                                     progressReporter?: IProgressReporter): Promise<boolean> {
     const workspaceFolder: vscode.WorkspaceFolder | undefined = vscode.workspace.getWorkspaceFolder(uri);
     const workspaceUri: vscode.Uri | undefined = workspaceFolder ? workspaceFolder.uri : undefined;
     const onClasspath = await isOnClasspath(uri.toString());
@@ -195,6 +197,7 @@ export async function startDebugging(mainClass: string, projectName: string, uri
     const debugConfig: vscode.DebugConfiguration = await constructDebugConfig(mainClass, projectName, workspaceUri);
     debugConfig.projectName = projectName;
     debugConfig.noDebug = noDebug;
+    debugConfig.__progressId = progressReporter?.getId();
 
     return vscode.debug.startDebugging(workspaceFolder, debugConfig);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -322,13 +322,16 @@ async function launchMain(mainMethods: IMainClassOption[], uri: vscode.Uri, noDe
         throw new utility.OperationCancelledError("");
     }
 
-    progressReporter.hide(true);
+    if (!mainClassPicker.isAutoPicked(mainMethods, autoPick)) {
+        progressReporter.hide(true);
+    }
+
     const pick = await mainClassPicker.showQuickPickWithRecentlyUsed(mainMethods, placeHolder, autoPick);
     if (!pick) {
         throw new utility.OperationCancelledError("");
     }
 
-    progressReporter.show();
+    progressReporter.report("Launch mainClass", "Launching the main class...");
     startDebugging(pick.mainClass, pick.projectName || "", uri, noDebug, progressReporter);
 }
 
@@ -355,14 +358,16 @@ async function runJavaProject(node: any, noDebug: boolean) {
             throw new utility.OperationCancelledError("");
         }
 
-        progressReporter.hide(true);
+        if (!mainClassPicker.isAutoPicked(mainClassesOptions)) {
+            progressReporter.hide(true);
+        }
         const pick = await mainClassPicker.showQuickPickWithRecentlyUsed(mainClassesOptions,
             "Select the main class to run.");
         if (!pick || progressReporter.isCancelled()) {
             throw new utility.OperationCancelledError("");
         }
 
-        progressReporter.show();
+        progressReporter.report("Launch mainClass", "Launching the main class...");
         const projectName: string | undefined = pick.projectName;
         const mainClass: string = pick.mainClass;
         const filePath: string | undefined = pick.filePath;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -232,7 +232,7 @@ async function applyHCR(hcrStatusBar: NotificationBar) {
 }
 
 async function runJavaFile(uri: vscode.Uri, noDebug: boolean) {
-    const progressReporter = progressProvider.createProgressReporterForPreLaunchTask(noDebug ? "Run" : "Debug");
+    const progressReporter = progressProvider.createProgressReporter(noDebug ? "Run" : "Debug", vscode.ProgressLocation.Notification, true);
     try {
         // Wait for Java Language Support extension being on Standard mode.
         const isOnStandardMode = await utility.waitForStandardMode(progressReporter);
@@ -256,7 +256,7 @@ async function runJavaFile(uri: vscode.Uri, noDebug: boolean) {
         const defaultPlaceHolder: string = "Select the main class to run";
 
         if (!hasMainMethods && !canRunTests) {
-            progressReporter.report("Resolve mainClass", "Resolving main class...");
+            progressReporter.report("Resolving mainClass...");
             const mainClasses: IMainClassOption[] = await utility.searchMainMethods();
             const placeHolder: string = `The file '${path.basename(uri.fsPath)}' is not executable, please select a main class you want to run.`;
             await launchMain(mainClasses, uri, noDebug, progressReporter, placeHolder, false /*autoPick*/);
@@ -331,7 +331,7 @@ async function launchMain(mainMethods: IMainClassOption[], uri: vscode.Uri, noDe
         throw new utility.OperationCancelledError("");
     }
 
-    progressReporter.report("Launch mainClass", "Launching the main class...");
+    progressReporter.report("Launching mainClass...");
     startDebugging(pick.mainClass, pick.projectName || "", uri, noDebug, progressReporter);
 }
 
@@ -344,9 +344,9 @@ async function runJavaProject(node: any, noDebug: boolean) {
         throw error;
     }
 
-    const progressReporter = progressProvider.createProgressReporterForPreLaunchTask(noDebug ? "Run" : "Debug");
+    const progressReporter = progressProvider.createProgressReporter(noDebug ? "Run" : "Debug", vscode.ProgressLocation.Notification, true);
     try {
-        progressReporter.report("Resolve mainClass", "Resolving main class...");
+        progressReporter.report("Resolving mainClass...");
         const mainClassesOptions: IMainClassOption[] = await utility.searchMainMethods(vscode.Uri.parse(node.uri));
         if (progressReporter.isCancelled()) {
             throw new utility.OperationCancelledError("");
@@ -367,7 +367,7 @@ async function runJavaProject(node: any, noDebug: boolean) {
             throw new utility.OperationCancelledError("");
         }
 
-        progressReporter.report("Launch mainClass", "Launching the main class...");
+        progressReporter.report("Launching mainClass...");
         const projectName: string | undefined = pick.projectName;
         const mainClass: string = pick.mainClass;
         const filePath: string | undefined = pick.filePath;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -256,8 +256,12 @@ async function runJavaFile(uri: vscode.Uri, noDebug: boolean) {
         const defaultPlaceHolder: string = "Select the main class to run";
 
         if (!hasMainMethods && !canRunTests) {
-            progressReporter.report("Resolving mainClass...");
+            progressReporter.report("Resolving main class...");
             const mainClasses: IMainClassOption[] = await utility.searchMainMethods();
+            if (progressReporter.isCancelled()) {
+                throw new utility.OperationCancelledError("");
+            }
+
             const placeHolder: string = `The file '${path.basename(uri.fsPath)}' is not executable, please select a main class you want to run.`;
             await launchMain(mainClasses, uri, noDebug, progressReporter, placeHolder, false /*autoPick*/);
         } else if (hasMainMethods && !canRunTests) {
@@ -331,7 +335,7 @@ async function launchMain(mainMethods: IMainClassOption[], uri: vscode.Uri, noDe
         throw new utility.OperationCancelledError("");
     }
 
-    progressReporter.report("Launching mainClass...");
+    progressReporter.report("Launching main class...");
     startDebugging(pick.mainClass, pick.projectName || "", uri, noDebug, progressReporter);
 }
 
@@ -346,7 +350,7 @@ async function runJavaProject(node: any, noDebug: boolean) {
 
     const progressReporter = progressProvider.createProgressReporter(noDebug ? "Run" : "Debug", vscode.ProgressLocation.Notification, true);
     try {
-        progressReporter.report("Resolving mainClass...");
+        progressReporter.report("Resolving main class...");
         const mainClassesOptions: IMainClassOption[] = await utility.searchMainMethods(vscode.Uri.parse(node.uri));
         if (progressReporter.isCancelled()) {
             throw new utility.OperationCancelledError("");
@@ -367,7 +371,7 @@ async function runJavaProject(node: any, noDebug: boolean) {
             throw new utility.OperationCancelledError("");
         }
 
-        progressReporter.report("Launching mainClass...");
+        progressReporter.report("Launching main class...");
         const projectName: string | undefined = pick.projectName;
         const mainClass: string = pick.mainClass;
         const filePath: string | undefined = pick.filePath;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -232,7 +232,7 @@ async function applyHCR(hcrStatusBar: NotificationBar) {
 }
 
 async function runJavaFile(uri: vscode.Uri, noDebug: boolean) {
-    const progressReporter = progressProvider.createProgressReporter(noDebug ? "Run" : "Debug", vscode.ProgressLocation.Notification, true);
+    const progressReporter = progressProvider.createProgressReporter(noDebug ? "Run" : "Debug");
     try {
         // Wait for Java Language Support extension being on Standard mode.
         const isOnStandardMode = await utility.waitForStandardMode(progressReporter);
@@ -348,7 +348,7 @@ async function runJavaProject(node: any, noDebug: boolean) {
         throw error;
     }
 
-    const progressReporter = progressProvider.createProgressReporter(noDebug ? "Run" : "Debug", vscode.ProgressLocation.Notification, true);
+    const progressReporter = progressProvider.createProgressReporter(noDebug ? "Run" : "Debug");
     try {
         progressReporter.report("Resolving main class...");
         const mainClassesOptions: IMainClassOption[] = await utility.searchMainMethods(vscode.Uri.parse(node.uri));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -278,7 +278,7 @@ async function runJavaFile(uri: vscode.Uri, noDebug: boolean) {
             }
         }
     } catch (ex) {
-        progressReporter.cancel();
+        progressReporter.done();
         if (ex instanceof utility.OperationCancelledError) {
             return;
         }
@@ -389,7 +389,7 @@ async function runJavaProject(node: any, noDebug: boolean) {
         debugConfig.__progressId = progressReporter.getId();
         vscode.debug.startDebugging(workspaceFolder, debugConfig);
     } catch (ex) {
-        progressReporter.cancel();
+        progressReporter.done();
         if (ex instanceof utility.OperationCancelledError) {
             return;
         }

--- a/src/mainClassPicker.ts
+++ b/src/mainClassPicker.ts
@@ -153,6 +153,22 @@ class MainClassPicker {
         return undefined;
     }
 
+    /**
+     * Checks whether the item options can be picked automatically without popping up the QuickPick box.
+     * @param options the item options to pick
+     * @param autoPick pick it automatically if only one option is available
+     */
+    public isAutoPicked(options: IMainClassOption[], autoPick?: boolean) {
+        const shouldAutoPick: boolean = (autoPick === undefined ? true : !!autoPick);
+        if (!options || !options.length) {
+            return true;
+        } else if (shouldAutoPick && options.length === 1) {
+            return true;
+        }
+
+        return false;
+    }
+
     private getMRUTimestamp(mainClassOption: IMainClassOption): number {
         return this.cache[this.getKey(mainClassOption)] || 0;
     }

--- a/src/processTree.ts
+++ b/src/processTree.ts
@@ -77,8 +77,8 @@ export function getProcesses(one: (pid: number, ppid: number, command: string, a
 
 			const wmic = join(process.env['WINDIR'] || 'C:\\Windows', 'System32', 'wbem', 'WMIC.exe');
 			proc = spawn(wmic, [ 'process', 'get', 'CommandLine,CreationDate,ParentProcessId,ProcessId' ]);
-			proc.stdout.setEncoding('utf8');
-			proc.stdout.on('data', lines(line => {
+			proc.stdout?.setEncoding('utf8');
+			proc.stdout?.on('data', lines(line => {
 				let matches = CMD_PAT.exec(line.trim());
 				if (matches && matches.length === 5) {
 					const pid = Number(matches[4]);
@@ -110,8 +110,8 @@ export function getProcesses(one: (pid: number, ppid: number, command: string, a
 		} else if (process.platform === 'darwin') {	// OS X
 
 			proc = spawn('/bin/ps', [ '-x', '-o', `pid,ppid,comm=${'a'.repeat(256)},command` ]);
-			proc.stdout.setEncoding('utf8');
-			proc.stdout.on('data', lines(line => {
+			proc.stdout?.setEncoding('utf8');
+			proc.stdout?.on('data', lines(line => {
 
 				const pid = Number(line.substr(0, 5));
 				const ppid = Number(line.substr(6, 5));
@@ -126,8 +126,8 @@ export function getProcesses(one: (pid: number, ppid: number, command: string, a
 		} else {	// linux
 
 			proc = spawn('/bin/ps', [ '-ax', '-o', 'pid,ppid,comm:20,command' ]);
-			proc.stdout.setEncoding('utf8');
-			proc.stdout.on('data', lines(line => {
+			proc.stdout?.setEncoding('utf8');
+			proc.stdout?.on('data', lines(line => {
 
 				const pid = Number(line.substr(0, 5));
 				const ppid = Number(line.substr(6, 5));
@@ -157,8 +157,8 @@ export function getProcesses(one: (pid: number, ppid: number, command: string, a
 			reject(err);
 		});
 
-		proc.stderr.setEncoding('utf8');
-		proc.stderr.on('data', data => {
+		proc.stderr?.setEncoding('utf8');
+		proc.stderr?.on('data', data => {
 			const e = data.toString();
 			if (e.indexOf('screen size is bogus') >= 0) {
 				// ignore this error silently; see https://github.com/microsoft/vscode/issues/75932

--- a/src/progressAPI.ts
+++ b/src/progressAPI.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { CancellationToken } from "vscode";
+import { CancellationToken, ProgressLocation } from "vscode";
 
 export interface IProgressReporter {
     /**
@@ -10,21 +10,37 @@ export interface IProgressReporter {
     getId(): string;
 
     /**
-     * Update the progress message.
-     * @param subTaskName the sub task name to update
-     * @param detailedMessage the detailed message to update
+     * Reports a progress message update.
+     * @param subTaskName the message shown in the status bar
+     * @param detailedMessage the detailed message shown in the notification
      */
     report(subTaskName: string, detailedMessage: string): void;
 
     /**
-     * Cancel the progress reporter.
+     * Shows the progress reporter.
+     */
+    show(): void;
+
+    /**
+     * Hides the progress reporter.
+     * @param onlyNotifications only hide the progress reporter when it's shown as notification
+     */
+    hide(onlyNotifications?: boolean): void;
+
+    /**
+     * Cancels the progress reporter.
      */
     cancel(): void;
 
     /**
-     * Is the progress reporter cancelled.
+     * Returns whether the progress reporter has been cancelled or completed.
      */
     isCancelled(): boolean;
+
+    /**
+     * Notifies the work is done that is either the task is completed or the user has cancelled it.
+     */
+    done(): void;
 
     /**
      * The CancellationToken to monitor if the progress reporter has been cancelled by the user.
@@ -32,29 +48,33 @@ export interface IProgressReporter {
     getCancellationToken(): CancellationToken;
 
     /**
-     * Dispose the progress reporter if the observed token has been cancelled.
+     * Disposes the progress reporter if the observed token has been cancelled.
      * @param token the cancellation token to observe
      */
     observe(token?: CancellationToken): void;
 }
 
-export interface IProgressReporterManager {
+export interface IProgressReporterProvider {
     /**
-     * Create a progress reporter.
+     * Creates a progress reporter.
      * @param jobName the job name
-     * @param showInStatusBar whether to show the progress in the status bar
+     * @param progressLocation The location at which progress should show
+     * @param cancellable Controls if a cancel button should show to allow the user
+     *                    to cancel the progress reporter. Note that currently only
+     *                    `ProgressLocation.Notification` is supporting to show a cancel
+     *                    button.
      */
-    create(jobName: string, showInStatusBar?: boolean): IProgressReporter;
+    createProgressReporter(jobName: string, progressLocation: ProgressLocation | { viewId: string }, cancellable?: boolean): IProgressReporter;
 
     /**
-     * Return the progress repoter with the progress id.
+     * Creates a progress reporter for the task to run before the debug session starts.
+     * @param jobName the job name
+     */
+    createProgressReporterForPreLaunchTask(jobName: string): IProgressReporter;
+
+    /**
+     * Returns the progress reporter with the progress id.
      * @param progressId the progress id
      */
-    get(progressId: string): IProgressReporter | undefined;
-
-    /**
-     * Remove the progress reporter from the progress reporter manager.
-     * @param progressReporter the progress reporter to remove
-     */
-    remove(progressReporter: IProgressReporter): void;
+    getProgressReporter(progressId: string): IProgressReporter | undefined;
 }

--- a/src/progressAPI.ts
+++ b/src/progressAPI.ts
@@ -3,6 +3,7 @@
 
 import { CancellationToken, ProgressLocation } from "vscode";
 
+/* tslint:disable */
 export interface IProgressReporter {
     /**
      * Returns the id of the progress reporter.
@@ -11,10 +12,27 @@ export interface IProgressReporter {
 
     /**
      * Reports a progress message update.
-     * @param subTaskName the message shown in the status bar
-     * @param detailedMessage the detailed message shown in the notification
+     * @param subTaskName the sub task name that's running
+     * @param detailedMessage a more detailed message to be shown in progress notifications
      */
-    report(subTaskName: string, detailedMessage: string): void;
+    report(subTaskName: string, detailedMessage?: string): void;
+
+    /**
+     * Reports a progress message update.
+     * @param subTaskName the sub task name that's running
+     * @param increment use `increment` to report discrete progress. Each call with a `increment`
+     *                  value will be summed up and reflected as overall progress until 100% is reached.
+     */
+    report(subTaskName: string, increment?: number): void;
+
+    /**
+     * Reports a progress message update.
+     * @param subTaskName the sub task name that's running
+     * @param detailedMessage a more detailed message to be shown in progress notifications
+     * @param increment use `increment` to report discrete progress. Each call with a `increment`
+     *                  value will be summed up and reflected as overall progress until 100% is reached.
+     */
+    report(subTaskName: string, detailedMessage: string, increment?: number): void;
 
     /**
      * Shows the progress reporter.
@@ -23,14 +41,9 @@ export interface IProgressReporter {
 
     /**
      * Hides the progress reporter.
-     * @param onlyNotifications only hide the progress reporter when it's shown as notification
+     * @param onlyNotifications only hide the progress reporter when it's shown as notification.
      */
     hide(onlyNotifications?: boolean): void;
-
-    /**
-     * Cancels the progress reporter.
-     */
-    cancel(): void;
 
     /**
      * Returns whether the progress reporter has been cancelled or completed.
@@ -54,7 +67,7 @@ export interface IProgressReporter {
     observe(token?: CancellationToken): void;
 }
 
-export interface IProgressReporterProvider {
+export interface IProgressProvider {
     /**
      * Creates a progress reporter.
      * @param jobName the job name
@@ -67,7 +80,9 @@ export interface IProgressReporterProvider {
     createProgressReporter(jobName: string, progressLocation: ProgressLocation | { viewId: string }, cancellable?: boolean): IProgressReporter;
 
     /**
-     * Creates a progress reporter for the task to run before the debug session starts.
+     * Creates a progress reporter for the preLaunch task that runs before the debug session starts.
+     * For example, building the workspace and calculating the launch configuration are the typical
+     * preLaunch tasks.
      * @param jobName the job name
      */
     createProgressReporterForPreLaunchTask(jobName: string): IProgressReporter;

--- a/src/progressAPI.ts
+++ b/src/progressAPI.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { CancellationToken } from "vscode";
+
+export interface IProgressReporter {
+    /**
+     * Returns the id of the progress reporter.
+     */
+    getId(): string;
+
+    /**
+     * Update the progress message.
+     * @param subTaskName the sub task name to update
+     * @param detailedMessage the detailed message to update
+     */
+    report(subTaskName: string, detailedMessage: string): void;
+
+    /**
+     * Cancel the progress reporter.
+     */
+    cancel(): void;
+
+    /**
+     * Is the progress reporter cancelled.
+     */
+    isCancelled(): boolean;
+
+    /**
+     * The CancellationToken to monitor if the progress reporter has been cancelled by the user.
+     */
+    getCancellationToken(): CancellationToken;
+
+    /**
+     * Dispose the progress reporter if the observed token has been cancelled.
+     * @param token the cancellation token to observe
+     */
+    observe(token?: CancellationToken): void;
+}
+
+export interface IProgressReporterManager {
+    /**
+     * Create a progress reporter.
+     * @param jobName the job name
+     * @param showInStatusBar whether to show the progress in the status bar
+     */
+    create(jobName: string, showInStatusBar?: boolean): IProgressReporter;
+
+    /**
+     * Return the progress repoter with the progress id.
+     * @param progressId the progress id
+     */
+    get(progressId: string): IProgressReporter | undefined;
+
+    /**
+     * Remove the progress reporter from the progress reporter manager.
+     * @param progressReporter the progress reporter to remove
+     */
+    remove(progressReporter: IProgressReporter): void;
+}

--- a/src/progressAPI.ts
+++ b/src/progressAPI.ts
@@ -56,13 +56,12 @@ export interface IProgressProvider {
     /**
      * Creates a progress reporter.
      * @param jobName the job name
-     * @param progressLocation The location at which progress should show
-     * @param cancellable Controls if a cancel button should show to allow the user
-     *                    to cancel the progress reporter. Note that currently only
-     *                    `ProgressLocation.Notification` is supporting to show a cancel
-     *                    button.
+     * @param progressLocation The location at which progress should show, defaults to `ProgressLocation.Notification`.
+     * @param cancellable Controls if a cancel button should show to allow the user to cancel the progress reporter,
+     *                    defaults to true. Note that currently only `ProgressLocation.Notification` is supporting
+     *                    to show a cancel button.
      */
-    createProgressReporter(jobName: string, progressLocation: ProgressLocation | { viewId: string }, cancellable?: boolean): IProgressReporter;
+    createProgressReporter(jobName: string, progressLocation?: ProgressLocation | { viewId: string }, cancellable?: boolean): IProgressReporter;
 
     /**
      * Returns the progress reporter with the progress id.

--- a/src/progressAPI.ts
+++ b/src/progressAPI.ts
@@ -3,7 +3,6 @@
 
 import { CancellationToken, ProgressLocation } from "vscode";
 
-/* tslint:disable */
 export interface IProgressReporter {
     /**
      * Returns the id of the progress reporter.
@@ -12,27 +11,13 @@ export interface IProgressReporter {
 
     /**
      * Reports a progress message update.
-     * @param subTaskName the sub task name that's running
-     * @param detailedMessage a more detailed message to be shown in progress notifications
-     */
-    report(subTaskName: string, detailedMessage?: string): void;
-
-    /**
-     * Reports a progress message update.
-     * @param subTaskName the sub task name that's running
+     * @param message the message to update
      * @param increment use `increment` to report discrete progress. Each call with a `increment`
      *                  value will be summed up and reflected as overall progress until 100% is reached.
+     *                  Note that currently only `ProgressLocation.Notification` is capable of showing
+     *                  discrete progress.
      */
-    report(subTaskName: string, increment?: number): void;
-
-    /**
-     * Reports a progress message update.
-     * @param subTaskName the sub task name that's running
-     * @param detailedMessage a more detailed message to be shown in progress notifications
-     * @param increment use `increment` to report discrete progress. Each call with a `increment`
-     *                  value will be summed up and reflected as overall progress until 100% is reached.
-     */
-    report(subTaskName: string, detailedMessage: string, increment?: number): void;
+    report(message: string, increment?: number): void;
 
     /**
      * Shows the progress reporter.
@@ -78,14 +63,6 @@ export interface IProgressProvider {
      *                    button.
      */
     createProgressReporter(jobName: string, progressLocation: ProgressLocation | { viewId: string }, cancellable?: boolean): IProgressReporter;
-
-    /**
-     * Creates a progress reporter for the preLaunch task that runs before the debug session starts.
-     * For example, building the workspace and calculating the launch configuration are the typical
-     * preLaunch tasks.
-     * @param jobName the job name
-     */
-    createProgressReporterForPreLaunchTask(jobName: string): IProgressReporter;
 
     /**
      * Returns the progress reporter with the progress id.

--- a/src/progressImpl.ts
+++ b/src/progressImpl.ts
@@ -55,20 +55,13 @@ class ProgressReporter implements IProgressReporter {
         return this._id;
     }
 
-    public report(subTaskName: string, detailedMessage?: string | number, increment?: number): void {
-        this._message = subTaskName || this._jobName;
+    public report(message: string, increment?: number): void {
         if (this._statusBarItem) {
-            this._statusBarItem.text = `$(sync~spin) ${this._message}...`;
+            const text = message ? `${this._jobName} - ${message}` : `${this._jobName}...`;
+            this._statusBarItem.text = `$(sync~spin) ${text}`;
         } else {
-            if (typeof increment === "number") {
-                this._increment = increment;
-            } else if (typeof detailedMessage === "number") {
-                this._increment = detailedMessage;
-            }
-
-            if (typeof detailedMessage === "string") {
-                this._message = detailedMessage || this._message;
-            }
+            this._message = message;
+            this._increment = increment;
         }
 
         this._progressEventEmitter.fire(undefined);
@@ -144,27 +137,11 @@ class ProgressReporter implements IProgressReporter {
     }
 }
 
-class PreLaunchTaskProgressReporter extends ProgressReporter {
-    constructor(jobName: string) {
-        super(jobName, ProgressLocation.Notification, true);
-    }
-
-    public report(subTaskName: string, detailedMessage?: string | number, increment?: number): void {
-        super.report("Building - " + subTaskName, detailedMessage, increment);
-    }
-}
-
 class ProgressProvider implements IProgressProvider {
     private store: { [key: string]: IProgressReporter } = {};
 
     public createProgressReporter(jobName: string, progressLocation: ProgressLocation, cancellable?: boolean): IProgressReporter {
         const progressReporter = new ProgressReporter(jobName, progressLocation, cancellable);
-        this.store[progressReporter.getId()] = progressReporter;
-        return progressReporter;
-    }
-
-    public createProgressReporterForPreLaunchTask(jobName: string): IProgressReporter {
-        const progressReporter = new PreLaunchTaskProgressReporter(jobName);
         this.store[progressReporter.getId()] = progressReporter;
         return progressReporter;
     }

--- a/src/progressImpl.ts
+++ b/src/progressImpl.ts
@@ -1,0 +1,136 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+import { v4 } from "uuid";
+import { CancellationToken, CancellationTokenSource, commands, Disposable, EventEmitter, ExtensionContext, ProgressLocation,
+    StatusBarAlignment, StatusBarItem, window, workspace } from "vscode";
+import { IProgressReporter, IProgressReporterManager } from "./progressAPI";
+
+const showProgressNotificationCommand = "_java.debug.showProgressNotification";
+export function registerProgressReporters(context: ExtensionContext) {
+    context.subscriptions.push(commands.registerCommand(showProgressNotificationCommand, async (progressReporter: JavaProgressReporter) => {
+        progressReporter.showProgressNotification();
+    }));
+}
+
+class JavaProgressReporter implements IProgressReporter {
+    public jobName: string;
+    public subTaskName: string;
+    public detailedMessage: string = "Building Java workspace...";
+
+    private _id: string = v4();
+    private _tokenSource = new CancellationTokenSource();
+    private _statusBarItem: StatusBarItem | undefined;
+    private _isProgressNotificationRunning: boolean = false;
+    private _cancelEventEmitter: EventEmitter<any>;
+    private _progressEventEmitter: EventEmitter<any>;
+    private _disposables: Disposable[] = [];
+
+    constructor(jobName: string, showInStatusBar?: boolean) {
+        this.jobName = jobName || "Java Job Status";
+        const config = workspace.getConfiguration("java.debug.settings");
+        if (showInStatusBar || !config.showRunStatusAsNotification) {
+            this._statusBarItem = window.createStatusBarItem(StatusBarAlignment.Left, 1);
+            this._statusBarItem.text = "$(sync~spin) Building...";
+            this._statusBarItem.command = {
+                title: "Check Java Build Status",
+                command: showProgressNotificationCommand,
+                arguments: [ this ],
+            };
+            this._statusBarItem.tooltip = "Check Java Build Status";
+            this._disposables.push(this._statusBarItem);
+        }
+
+        this._cancelEventEmitter = new EventEmitter<any>();
+        this._progressEventEmitter = new EventEmitter<any>();
+        this._disposables.push(this._cancelEventEmitter);
+        this._disposables.push(this._progressEventEmitter);
+        this._disposables.push(this._tokenSource);
+    }
+
+    public getId(): string {
+        return this._id;
+    }
+
+    public report(subTaskName: string, detailedMessage: string): void {
+        this.subTaskName = subTaskName;
+        this.detailedMessage = detailedMessage || subTaskName || "Building...";
+        this._progressEventEmitter.fire(undefined);
+        if (this._statusBarItem) {
+            this._statusBarItem.text = subTaskName ? `$(sync~spin) Building - ${subTaskName}...` : "$(sync~spin) Building...";
+            this._statusBarItem.show();
+        } else {
+            this.showProgressNotification();
+        }
+    }
+
+    public cancel() {
+        this._tokenSource.cancel();
+        this._cancelEventEmitter.fire(undefined);
+        this._statusBarItem?.hide();
+        this._disposables.forEach((disposable) => disposable.dispose());
+        progressReporterManager.remove(this);
+    }
+
+    public isCancelled(): boolean {
+        return this.getCancellationToken().isCancellationRequested;
+    }
+
+    public getCancellationToken(): CancellationToken {
+        return this._tokenSource.token;
+    }
+
+    public observe(token?: CancellationToken): void {
+        token?.onCancellationRequested(() => {
+            this.cancel();
+        });
+    }
+
+    public showProgressNotification() {
+        if (this._isProgressNotificationRunning) {
+            return;
+        }
+
+        this._isProgressNotificationRunning = true;
+        window.withProgress<boolean>({
+            location: ProgressLocation.Notification,
+            title: `[${this.jobName}](command:java.show.server.task.status)`,
+            cancellable: true,
+        }, (progress, token) => {
+            progress.report({
+                message: this.detailedMessage,
+            });
+            this._progressEventEmitter.event(() => {
+                progress.report({
+                    message: this.detailedMessage,
+                });
+            });
+            this.observe(token);
+            return new Promise((resolve) => {
+                this._cancelEventEmitter.event(() => {
+                    resolve(true);
+                });
+            });
+        });
+    }
+}
+
+class JavaProgressReporterManager implements IProgressReporterManager {
+    private store: { [key: string]: IProgressReporter } = {};
+
+    public create(jobName: string, showInStatusBar?: boolean): IProgressReporter {
+        const progressReporter = new JavaProgressReporter(jobName, showInStatusBar);
+        this.store[progressReporter.getId()] = progressReporter;
+        return progressReporter;
+    }
+
+    public get(progressId: string): IProgressReporter | undefined {
+        return this.store[progressId];
+    }
+
+    public remove(progressReporter: IProgressReporter) {
+        delete this.store[progressReporter.getId()];
+    }
+}
+
+export const progressReporterManager: IProgressReporterManager = new JavaProgressReporterManager();

--- a/src/progressImpl.ts
+++ b/src/progressImpl.ts
@@ -19,8 +19,8 @@ class ProgressReporter implements IProgressReporter {
 
     private _tokenSource = new CancellationTokenSource();
     private _statusBarItem: StatusBarItem | undefined;
-    private _cancelProgressEventEmitter: EventEmitter<any>;
-    private _progressEventEmitter: EventEmitter<any>;
+    private _cancelProgressEventEmitter: EventEmitter<void>;
+    private _progressEventEmitter: EventEmitter<void>;
     private _disposables: Disposable[] = [];
 
     constructor(jobName: string, progressLocation: ProgressLocation | { viewId: string }, cancellable?: boolean) {
@@ -59,12 +59,11 @@ class ProgressReporter implements IProgressReporter {
         if (this._statusBarItem) {
             const text = message ? `${this._jobName} - ${message}` : `${this._jobName}...`;
             this._statusBarItem.text = `$(sync~spin) ${text}`;
-        } else {
-            this._message = message;
-            this._increment = increment;
         }
 
-        this._progressEventEmitter.fire(undefined);
+        this._message = message;
+        this._increment = increment;
+        this._progressEventEmitter.fire();
         this.show();
     }
 
@@ -79,7 +78,7 @@ class ProgressReporter implements IProgressReporter {
 
     public hide(onlyNotifications?: boolean): void {
         if (onlyNotifications && this._progressLocation === ProgressLocation.Notification) {
-            this._cancelProgressEventEmitter.fire(undefined);
+            this._cancelProgressEventEmitter.fire();
             this._isShown = false;
         }
     }
@@ -90,7 +89,7 @@ class ProgressReporter implements IProgressReporter {
 
     public done(): void {
         this._tokenSource.cancel();
-        this._cancelProgressEventEmitter.fire(undefined);
+        this._cancelProgressEventEmitter.fire();
         this._statusBarItem?.hide();
         this._disposables.forEach((disposable) => disposable.dispose());
         (<ProgressProvider> progressProvider).remove(this);

--- a/src/progressImpl.ts
+++ b/src/progressImpl.ts
@@ -23,10 +23,10 @@ class ProgressReporter implements IProgressReporter {
     private _progressEventEmitter: EventEmitter<void>;
     private _disposables: Disposable[] = [];
 
-    constructor(jobName: string, progressLocation: ProgressLocation | { viewId: string }, cancellable?: boolean) {
+    constructor(jobName: string, progressLocation: ProgressLocation | { viewId: string }, cancellable: boolean) {
         this._jobName = jobName;
         this._progressLocation = progressLocation || ProgressLocation.Notification;
-        this._cancellable = !!cancellable;
+        this._cancellable = cancellable;
         const config = workspace.getConfiguration("java");
         if (config.silentNotification && this._progressLocation === ProgressLocation.Notification) {
             this._progressLocation = ProgressLocation.Window;
@@ -139,8 +139,10 @@ class ProgressReporter implements IProgressReporter {
 class ProgressProvider implements IProgressProvider {
     private store: { [key: string]: IProgressReporter } = {};
 
-    public createProgressReporter(jobName: string, progressLocation: ProgressLocation, cancellable?: boolean): IProgressReporter {
-        const progressReporter = new ProgressReporter(jobName, progressLocation, cancellable);
+    public createProgressReporter(jobName: string, progressLocation?: ProgressLocation | { viewId: string },
+                                  cancellable?: boolean): IProgressReporter {
+        const progressReporter = new ProgressReporter(jobName, progressLocation || ProgressLocation.Notification,
+                                cancellable === undefined ? true : !!cancellable);
         this.store[progressReporter.getId()] = progressReporter;
         return progressReporter;
     }

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -227,7 +227,7 @@ export enum ServerMode {
  */
 export async function waitForStandardMode(progressReporter: IProgressReporter): Promise<boolean> {
     if (await isImportingProjects()) {
-        progressReporter.report("Import", "Importing Java projects...");
+        progressReporter.report("Importing projects...");
     }
 
     const api = await getJavaExtensionAPI(progressReporter);
@@ -243,7 +243,7 @@ export async function waitForStandardMode(progressReporter: IProgressReporter): 
                 return true;
             }
 
-            progressReporter?.report("Import", "Importing Java projects...");
+            progressReporter?.report("Importing projects...");
             return new Promise<boolean>((resolve) => {
                 progressReporter.getCancellationToken().onCancellationRequested(() => {
                     resolve(false);
@@ -260,7 +260,7 @@ export async function waitForStandardMode(progressReporter: IProgressReporter): 
 
         return false;
     } else if (api && api.serverMode === ServerMode.HYBRID) {
-        progressReporter.report("Import", "Importing Java projects...");
+        progressReporter.report("Importing projects...");
         return new Promise<boolean>((resolve) => {
             progressReporter.getCancellationToken().onCancellationRequested(() => {
                 resolve(false);

--- a/tslint.json
+++ b/tslint.json
@@ -9,7 +9,7 @@
         "no-duplicate-variable": true,
         "max-classes-per-file": false,
         "no-implicit-dependencies": [
-            false, // Turned off due to: https://github.com/microsoft/vscode/issues/78019
+            false,
             "dev"
         ],
         "no-empty": false,


### PR DESCRIPTION
This PR includes:
- Use a consistent progress reporter to report the build status before running/debugging an application. 
By default, progress notifications are used to display status. You can also use the status bar to display status by enabling user settings `java.silentNotification`.

- Expose an extension API for test runner to use the same progress reporter. In addition, when third-party extensions such as test runner call the startDebugging API to start the debugger, they can add an attribute `__progressId` to the launchConfiguration so that the debugger can use the same progress reporter to report progress.
```ts
// The debugger will export the progressProvider instance to others for reuse.
{
  progressProvider: IProgressProvider
}

export interface IProgressReporter {
    /**
     * Returns the id of the progress reporter.
     */
    getId(): string;

    /**
     * Reports a progress message update.
     * @param message the message to update
     * @param increment use `increment` to report discrete progress. Each call with a `increment`
     *                  value will be summed up and reflected as overall progress until 100% is reached.
     *                  Note that currently only `ProgressLocation.Notification` is capable of showing
     *                  discrete progress.
     */
    report(message: string, increment?: number): void;

    /**
     * Shows the progress reporter.
     */
    show(): void;

    /**
     * Hides the progress reporter.
     * @param onlyNotifications only hide the progress reporter when it's shown as notification.
     */
    hide(onlyNotifications?: boolean): void;

    /**
     * Returns whether the progress reporter has been cancelled or completed.
     */
    isCancelled(): boolean;

    /**
     * Notifies the work is done that is either the task is completed or the user has cancelled it.
     */
    done(): void;

    /**
     * The CancellationToken to monitor if the progress reporter has been cancelled by the user.
     */
    getCancellationToken(): CancellationToken;

    /**
     * Disposes the progress reporter if the observed token has been cancelled.
     * @param token the cancellation token to observe
     */
    observe(token?: CancellationToken): void;
}

export interface IProgressProvider {
    /**
     * Creates a progress reporter.
     * @param jobName the job name
     * @param progressLocation The location at which progress should show, defaults to `ProgressLocation.Notification`.
     * @param cancellable Controls if a cancel button should show to allow the user to cancel the progress reporter,
     *                    defaults to true. Note that currently only `ProgressLocation.Notification` is supporting
     *                    to show a cancel button.
     */
    createProgressReporter(jobName: string, progressLocation?: ProgressLocation | { viewId: string }, cancellable?: boolean): IProgressReporter;

    /**
     * Returns the progress reporter with the progress id.
     * @param progressId the progress id
     */
    getProgressReporter(progressId: string): IProgressReporter | undefined;
}

```