### PR TITLE
Simplify the name label of the launch configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -500,7 +500,7 @@
             "description": "%java.debugger.snippet.launch.description%",
             "body": {
               "type": "java",
-              "name": "Debug (Launch)",
+              "name": "Launch Java Program",
               "request": "launch",
               "mainClass": ""
             }
@@ -510,7 +510,7 @@
             "description": "%java.debugger.snippet.launchInExternalTerminal.description%",
             "body": {
               "type": "java",
-              "name": "Debug (Launch) - External Terminal",
+              "name": "Launch External Terminal",
               "request": "launch",
               "console": "externalTerminal",
               "mainClass": ""
@@ -521,7 +521,7 @@
             "description": "%java.debugger.snippet.launchCurrentFile.description%",
             "body": {
               "type": "java",
-              "name": "Debug (Launch) - Current File",
+              "name": "Launch Current File",
               "request": "launch",
               "mainClass": "^\"\\${file}\""
             }
@@ -531,7 +531,7 @@
             "description": "%java.debugger.snippet.launchWithArgumentsPrompt.description%",
             "body": {
               "type": "java",
-              "name": "Debug (Launch) with Arguments Prompt",
+              "name": "Launch with Arguments Prompt",
               "request": "launch",
               "mainClass": "",
               "args": "^\"\\${command:SpecifyProgramArgs}\""
@@ -542,7 +542,7 @@
             "description": "%java.debugger.snippet.attach.description%",
             "body": {
               "type": "java",
-              "name": "Debug (Attach)",
+              "name": "Attach",
               "request": "attach",
               "hostName": "localhost",
               "port": "<debug port of the debuggee>"
@@ -563,7 +563,7 @@
             "description": "%java.debugger.snippet.attachRemote.description%",
             "body": {
               "type": "java",
-              "name": "Debug (Attach) - Remote",
+              "name": "Attach to Remote Program",
               "request": "attach",
               "hostName": "<The host name or ip address of remote debuggee>",
               "port": "<debug port of remote debuggee>"

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -94,7 +94,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
             progressReporter.observe(token);
             const defaultLaunchConfig = {
                 type: "java",
-                name: "Debug (Launch) - Current File",
+                name: "Launch Current File",
                 request: "launch",
                 // tslint:disable-next-line
                 mainClass: "${file}",
@@ -116,7 +116,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                 const launchConfigs = mainClasses.map((item) => {
                     return {
                         ...defaultLaunchConfig,
-                        name: this.constructLaunchConfigName(item.mainClass, cache, item.projectName),
+                        name: this.constructLaunchConfigName(item.mainClass, cache),
                         mainClass: item.mainClass,
                         projectName: item.projectName,
                     };
@@ -154,12 +154,8 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
         }
     }
 
-    private constructLaunchConfigName(mainClass: string, cache: {[key: string]: any}, projectName?: string) {
-        const prefix = "Debug (Launch)-";
-        let name = prefix + mainClass.substr(mainClass.lastIndexOf(".") + 1);
-        if (projectName !== undefined) {
-            name += `<${projectName}>`;
-        }
+    private constructLaunchConfigName(mainClass: string, cache: {[key: string]: any}) {
+        const name = `Launch ${mainClass.substr(mainClass.lastIndexOf(".") + 1)}`;
         if (cache[name] === undefined) {
             cache[name] = 0;
             return name;

--- a/src/debugCodeLensProvider.ts
+++ b/src/debugCodeLensProvider.ts
@@ -152,7 +152,7 @@ async function constructDebugConfig(mainClass: string, projectName: string, work
     if (!debugConfig) {
         debugConfig = {
             type: "java",
-            name: `CodeLens (Launch) - ${mainClass.substr(mainClass.lastIndexOf(".") + 1)}`,
+            name: `Launch ${mainClass.substr(mainClass.lastIndexOf(".") + 1)}`,
             request: "launch",
             mainClass,
             projectName,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -384,7 +384,7 @@ async function runJavaProject(node: any, noDebug: boolean) {
         });
         const debugConfig = existConfig || {
             type: "java",
-            name: `Launch - ${mainClass.substr(mainClass.lastIndexOf(".") + 1)}`,
+            name: `Launch ${mainClass.substr(mainClass.lastIndexOf(".") + 1)}`,
             request: "launch",
             mainClass,
             projectName,


### PR DESCRIPTION
Simplify the launch configuration name because it will displayed at the status bar. 

The old name:
![image](https://user-images.githubusercontent.com/14052197/102184331-3eb12c00-3eea-11eb-841a-46c421c8b5ac.png)

The simplified name:
![image](https://user-images.githubusercontent.com/14052197/102184044-c8142e80-3ee9-11eb-8b80-4af631ba8cbb.png)