### PR TITLE
Adopt new APIs from vscode-tas-client

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4494,9 +4494,9 @@
             "dev": true
         },
         "tas-client": {
-            "version": "0.1.16",
-            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.16.tgz",
-            "integrity": "sha512-ZMGg7dGXiYVJHYusDpUb/Ilg+iPNYZdKJSIA2ADn0f2RovHWM0TpNVe2YHPEc0hdFMsUwWKS5pCRzLnlUqcqGg==",
+            "version": "0.1.21",
+            "resolved": "https://registry.npmjs.org/tas-client/-/tas-client-0.1.21.tgz",
+            "integrity": "sha512-7UuIwOXarCYoCTrQHY5n7M+63XuwMC0sVUdbPQzxqDB9wMjIW0JF39dnp3yoJnxr4jJUVhPtvkkXZbAD0BxCcA==",
             "requires": {
                 "axios": "^0.21.1"
             }
@@ -4974,11 +4974,11 @@
             }
         },
         "vscode-tas-client": {
-            "version": "0.1.17",
-            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.17.tgz",
-            "integrity": "sha512-5uqMeg7sjsu1/QkmuRtBOXtZnnrCXAMEihbOSxan3bk2NdA/nZvhfhfLh8gd9FlBBL56QH69I8Zn25B2yGPRng==",
+            "version": "0.1.22",
+            "resolved": "https://registry.npmjs.org/vscode-tas-client/-/vscode-tas-client-0.1.22.tgz",
+            "integrity": "sha512-1sYH73nhiSRVQgfZkLQNJW7VzhKM9qNbCe8QyXgiKkLhH4GflDXRPAK4yy4P41jUgula+Fc9G7i5imj1dlKfaw==",
             "requires": {
-                "tas-client": "0.1.16"
+                "tas-client": "0.1.21"
             }
         },
         "vscode-test": {

--- a/package.json
+++ b/package.json
@@ -787,6 +787,6 @@
     "uuid": "^8.3.1",
     "vscode-extension-telemetry": "^0.1.6",
     "vscode-extension-telemetry-wrapper": "^0.9.0",
-    "vscode-tas-client": "^0.1.17"
+    "vscode-tas-client": "^0.1.22"
   }
 }

--- a/src/experimentationService.ts
+++ b/src/experimentationService.ts
@@ -3,7 +3,7 @@
 
 import * as vscode from "vscode";
 import { addContextProperty, sendInfo } from "vscode-extension-telemetry-wrapper";
-import { getExperimentationService, IExperimentationService, IExperimentationTelemetry, TargetPopulation } from "vscode-tas-client";
+import { getExperimentationServiceAsync, IExperimentationService, IExperimentationTelemetry, TargetPopulation } from "vscode-tas-client";
 
 class ExperimentationTelemetry implements IExperimentationTelemetry {
 
@@ -27,12 +27,14 @@ export function getExpService() {
     return expService;
 }
 
-export function initExpService(context: vscode.ExtensionContext): void {
+export async function initExpService(context: vscode.ExtensionContext): Promise<void> {
     const packageJson: {[key: string]: any} = require("../package.json");
     // tslint:disable: no-string-literal
     const extensionName = `${packageJson["publisher"]}.${packageJson["name"]}`;
     const extensionVersion = packageJson["version"];
     // tslint:enable: no-string-literal
-    expService = getExperimentationService(extensionName, extensionVersion,
+
+    // The async version will await the initializePromise to make sure shared property is set
+    expService = await getExperimentationServiceAsync(extensionName, extensionVersion,
         TargetPopulation.Public, new ExperimentationTelemetry(), context.globalState);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,10 +27,10 @@ import { initializeThreadOperations } from "./threadOperations";
 import * as utility from "./utility";
 
 export async function activate(context: vscode.ExtensionContext): Promise<any> {
-    await initExpService(context);
     await initializeFromJsonFile(context.asAbsolutePath("./package.json"), {
         firstParty: true,
     });
+    await initExpService(context);
     return instrumentOperation("activation", initializeExtension)(context);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,6 +27,7 @@ import { initializeThreadOperations } from "./threadOperations";
 import * as utility from "./utility";
 
 export async function activate(context: vscode.ExtensionContext): Promise<any> {
+    await initExpService(context);
     await initializeFromJsonFile(context.asAbsolutePath("./package.json"), {
         firstParty: true,
     });
@@ -37,7 +38,6 @@ function initializeExtension(_operationId: string, context: vscode.ExtensionCont
     // Deprecated
     logger.initialize(context, true);
 
-    initExpService(context);
     registerDebugEventListener(context);
     context.subscriptions.push(logger);
     context.subscriptions.push(vscode.window.registerTerminalLinkProvider(new JavaTerminalLinkProvder()));


### PR DESCRIPTION
Move `initExpService()` ahead of activation operation to make sure all the telemetries will set the context properties.

Signed-off-by: Sheng Chen <sheche@microsoft.com>