### PR TITLE
Remove existing encoding workarounds from client side

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Please also check the documentation of [Language Support for Java by Red Hat](ht
 - `sourcePaths` - The extra source directories of the program. The debugger looks for source code from project settings by default. This option allows the debugger to look for source code in extra directories.
 - `modulePaths` - The modulepaths for launching the JVM. If not specified, the debugger will automatically resolve from current project.
 - `classPaths` - The classpaths for launching the JVM. If not specified, the debugger will automatically resolve from current project.
-- `encoding` - The `file.encoding` setting for the JVM. If not specified, 'UTF-8' will be used. Possible values can be found in https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html.
+- `encoding` - The `file.encoding` setting for the JVM. Possible values can be found in https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html.
 - `vmArgs` - The extra options and system properties for the JVM (e.g. -Xms\<size\> -Xmx\<size\> -D\<name\>=\<value\>), it accepts a string or an array of string.
 - `projectName` - The preferred project in which the debugger searches for classes. There could be duplicated class names in different projects. This setting also works when the debugger looks for the specified main class when launching a program. It is required when the workspace has multiple java projects, otherwise the expression evaluation and conditional breakpoint may not work.
 - `cwd` - The working directory of the program. Defaults to `${workspaceFolder}`.

--- a/package.nls.es.json
+++ b/package.nls.es.json
@@ -6,7 +6,7 @@
     "java.debugger.launch.modulePaths.description": "Los modulepaths para el lanzamiento de la JVM.  Si no se especifica, el depurador se resolverá automáticamente a partir del proyecto actual.",
     "java.debugger.launch.classPaths.description": "Los classpath para el lanzamiento de la JVM. Si no se especifica, el depurador se resolverá automáticamente a partir del proyecto actual.",
     "java.debugger.launch.sourcePaths.description": "Los directorios de fuentes extras del programa. El depurador busca el código fuente de los ajustes del proyecto por defecto. Esta opción permite al depurador buscar el código fuente en directorios extra.",
-    "java.debugger.launch.encoding.description": "La configuración de codificación de archivos para la JVM. Si no se especifica, se usará 'UTF-8'. Los posibles valores se pueden encontrar en https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html.",
+    "java.debugger.launch.encoding.description": "La configuración de codificación de archivos para la JVM. Los posibles valores se pueden encontrar en https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html.",
     "java.debugger.launch.cwd.description": "El directorio de trabajo del programa. Por defecto es la raíz del área de trabajo actual.",
     "java.debugger.launch.env.description": "Las variables de entorno adicionales para el programa.",
     "java.debugger.launch.stopOnEntry.description": "Pausar automáticamente el programa después del lanzamiento.",

--- a/package.nls.json
+++ b/package.nls.json
@@ -14,7 +14,7 @@
     "java.debugger.launch.classPaths.test": "The classpaths within 'test' scope of current project.",
     "java.debugger.launch.classPaths.exclude": "The path after '!' will be excluded from the classpaths.",
     "java.debugger.launch.sourcePaths.description": "The extra source directories of the program. The debugger looks for source code from project settings by default. This option allows the debugger to look for source code in extra directories.",
-    "java.debugger.launch.encoding.description": "The file.encoding setting for the JVM. If not specified, 'UTF-8' will be used. Possible values can be found in https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html.",
+    "java.debugger.launch.encoding.description": "The file.encoding setting for the JVM. Possible values can be found in https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html.",
     "java.debugger.launch.cwd.description": "The working directory of the program. Defaults to the current workspace root.",
     "java.debugger.launch.env.description": "The extra environment variables for the program.",
     "java.debugger.launch.envFile.description": "Absolute path to a file containing environment variable definitions.",

--- a/package.nls.zh.json
+++ b/package.nls.zh.json
@@ -14,7 +14,7 @@
     "java.debugger.launch.classPaths.test": "当前工程中属于 test 作用域的类路径。",
     "java.debugger.launch.classPaths.exclude": "'!' 之后的路径将会从类路径中去除。",
     "java.debugger.launch.sourcePaths.description": "应用程序的额外源代码目录。调试器默认从工程配置中查找源代码。此选项允许调试器在额外目录中查找源代码。",
-    "java.debugger.launch.encoding.description": "JVM的file.encoding设置。如果未指定，将使用“UTF-8”。可以在http://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html中找到可能的值。",
+    "java.debugger.launch.encoding.description": "JVM的file.encoding设置。可以在http://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html中找到可能的值。",
     "java.debugger.launch.cwd.description": "应用程序的工作目录。默认为当前工作空间根目录。",
     "java.debugger.launch.env.description": "启动应用程序时自定义的环境变量。",
     "java.debugger.launch.envFile.description": "环境变量文件绝对路径。",

--- a/scripts/launcher.bat
+++ b/scripts/launcher.bat
@@ -1,7 +1,0 @@
-@echo off
-
-REM Change code page to UTF-8 for better compatibility.
-@chcp.com 65001 > NUL 
-
-REM Execute real command passed by args
-%*

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -315,11 +315,9 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                     config.shortenCommandLine = await getShortenApproachForCLI(config, targetJavaVersion);
                 }
 
-                if (process.platform === "win32" && config.console !== "internalConsole") {
-                    const launcherScript: string = utility.getLauncherScriptPath();
-                    if (!launcherScript.includes(" ") || !utility.isGitBash(config.console === "integratedTerminal")) {
-                        config.launcherScript = launcherScript;
-                    }
+                // VS Code internal console uses UTF-8 to display output by default.
+                if (config.console === "internalConsole" && !config.encoding) {
+                    config.encoding = "UTF-8";
                 }
             } else if (config.request === "attach") {
                 if (config.hostName && config.port && Number.isInteger(Number(config.port))) {

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import * as path from "path";
 import * as vscode from "vscode";
 import { sendError, sendInfo, setUserError } from "vscode-extension-telemetry-wrapper";
 import { Type } from "./javaLogger";
@@ -11,7 +10,6 @@ import { IProgressReporter } from "./progressAPI";
 const TROUBLESHOOTING_LINK = "https://github.com/Microsoft/vscode-java-debug/blob/master/Troubleshooting.md";
 const LEARN_MORE = "Learn More";
 const JAVA_EXTENSION_ID = "redhat.java";
-const DEBUGGER_EXTENSION_ID = "vscjava.vscode-java-debug";
 
 export class UserError extends Error {
     public context: ITroubleshootingMessage;
@@ -200,11 +198,6 @@ export function isJavaExtEnabled(): boolean {
 export function isJavaExtActivated(): boolean {
     const javaExt = vscode.extensions.getExtension(JAVA_EXTENSION_ID);
     return !!javaExt && javaExt.isActive;
-}
-
-export function getLauncherScriptPath() {
-    const ext = vscode.extensions.getExtension(DEBUGGER_EXTENSION_ID)!;
-    return path.join(ext.extensionPath, "scripts", "launcher.bat");
 }
 
 export function isGitBash(isIntegratedTerminal: boolean): boolean {


### PR DESCRIPTION
Fixes microsoft/vscode-java-pack#720
Fixes microsoft/vscode-java-pack#756
Fixes #622
Fixes #623
Fixes #646
Fixes #813

This PR made such changes:
- Remove the launcher.bat from the generated command line, since it brings some side effects on Windows.
- If launching application in terminals (e.g. cmd/ps), then make Java application and terminal to use the platform default encoding.
- If launching application in VS Code Internal Console (aka. Debug Console), then use UTF-8 in Java application because VS Code Debug Console use UTF-8 to display output. 

For Windows user, the recommended approach to solve encoding issue is to change the system locale to the target language. Learn more from the Encoding Troubleshooting Guide. https://github.com/microsoft/vscode-java-debug/blob/main/Troubleshooting_encoding.md
![image](https://user-images.githubusercontent.com/14052197/138408027-da71d3f4-7f64-4bfb-8b34-89d0605606f5.png)
