### PR TITLE
Add check to determine if javaExec is specified in the

### DIFF
--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -284,8 +284,10 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                     });
                 }
 
-                config.javaExec = await lsPlugin.resolveJavaExecutable(config.mainClass, config.projectName);
-                // Add the default launch options to the config.
+				if (!config.javaExec)
+                	config.javaExec = await lsPlugin.resolveJavaExecutable(config.mainClass, config.projectName);
+
+				// Add the default launch options to the config.
                 config.cwd = config.cwd || _.get(folder, "uri.fsPath");
                 if (Array.isArray(config.args)) {
                     config.args = this.concatArgs(config.args);


### PR DESCRIPTION
This fork allows you to specify the javaExec to use for executing the java virtual machine. It can be specified in your launch configuration options, or, if not specified, will use the current behavior of resolving. 