### PR TITLE
Fix problemMatcher patterns for the watch task (#1136)

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -25,8 +25,8 @@
 				],
 				"background": {
 					"activeOnStart": true,
-					"beginsPattern": "Compilation \\w+ starting…",
-					"endsPattern": "Compilation\\s+finished"
+					"beginsPattern": "Compiler '[^']+' starting",
+					"endsPattern": "Compiler '[^']+' finished"
 				}
 			},
 			"isBackground": true,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,6 +35,9 @@ module.exports = function (env, argv) {
           'applicationinsights-native-metrics': 'commonjs applicationinsights-native-metrics', // ignored because we don't ship native module
           vscode: 'commonjs vscode'
         },
-        devtool: 'source-map'
+        devtool: 'source-map',
+        infrastructureLogging: {
+          level: 'log'
+        }
       }];
 };


### PR DESCRIPTION
Webpack output patterns have changed since these patterns were written,
without this change the default launch config hangs.

Fixes microsoft/vscode-java-debug#1136