### PR TITLE
Send logpoint messages to the debug console

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -4,6 +4,7 @@
 export const JAVA_LANGID: string = "java";
 export const HCR_EVENT = "hotcodereplace";
 export const USER_NOTIFICATION_EVENT = "usernotification";
+export const LOGPOINT_EVENT = "logpoint";
 
 export enum ClasspathVariable {
     Auto = "$Auto",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { dispose as disposeTelemetryWrapper, initializeFromJsonFile, instrumentO
     instrumentOperationAsVsCodeCommand, setUserError } from "vscode-extension-telemetry-wrapper";
 import * as commands from "./commands";
 import { JavaDebugConfigurationProvider } from "./configurationProvider";
-import { HCR_EVENT, JAVA_LANGID, USER_NOTIFICATION_EVENT } from "./constants";
+import { HCR_EVENT, JAVA_LANGID, USER_NOTIFICATION_EVENT, LOGPOINT_EVENT } from "./constants";
 import { NotificationBar } from "./customWidget";
 import { initializeCodeLensProvider, startDebugging } from "./debugCodeLensProvider";
 import { initExpService } from "./experimentationService";
@@ -124,6 +124,8 @@ function registerDebugEventListener(context: vscode.ExtensionContext) {
             handleHotCodeReplaceCustomEvent(customEvent);
         } else if (customEvent.event === USER_NOTIFICATION_EVENT) {
             handleUserNotification(customEvent);
+        } else if (customEvent.event === LOGPOINT_EVENT) {
+            handleLogPoint(customEvent);
         }
     }));
 }
@@ -140,6 +142,10 @@ function handleUserNotification(customEvent: vscode.DebugSessionCustomEvent) {
     } else {
         vscode.window.showInformationMessage(customEvent.body.message);
     }
+}
+
+function handleLogPoint(customEvent: vscode.DebugSessionCustomEvent) {
+    vscode.debug.activeDebugConsole.appendLine(customEvent.body.message);
 }
 
 function fetchUsageData() {


### PR DESCRIPTION
This change receives logpoint messages as "logpoint" custom events from the java-debug java extension, and then prints them to the current active debug console.

Together with microsoft/java-debug#402, this would address microsoft/vscode-java-debug#710