### PR TITLE
Enable Java terminal link provider on all terminals

### DIFF
--- a/src/terminalLinkProvider.ts
+++ b/src/terminalLinkProvider.ts
@@ -15,10 +15,6 @@ export class JavaTerminalLinkProvder implements TerminalLinkProvider<IJavaTermin
      * @return A list of terminal links for the given line.
      */
     public provideTerminalLinks(context: TerminalLinkContext, _token: CancellationToken): ProviderResult<IJavaTerminalLink[]> {
-        if (context.terminal.name !== "Java Debug Console" && context.terminal.name !== "Java Process Console") {
-            return [];
-        }
-
         const regex = new RegExp("(\\sat\\s+)([\\w$\\.]+\\/)?(([\\w$]+\\.)+[<\\w$>]+)\\(([\\w-$]+\\.java:\\d+)\\)");
         const result: RegExpExecArray | null = regex.exec(context.line);
         if (result && result.length) {


### PR DESCRIPTION
This is a follow-up of PR https://github.com/microsoft/java-debug/pull/414 and https://github.com/redhat-developer/vscode-java/issues/2463.

Enabling Java terminal link providers on all terminals can also benefit the scenarios of running Maven command in VS Code terminal.