### PR TITLE
Add support to specify java executable

### DIFF
--- a/package.json
+++ b/package.json
@@ -379,6 +379,11 @@
                 "description": "%java.debugger.launch.mainClass.description%",
                 "default": ""
               },
+              "javaExec": {
+                "type": "string",
+                "description": "%java.debugger.launch.javaExec.description%",
+                "default": ""
+              },
               "args": {
                 "type": [
                   "array",

--- a/package.nls.json
+++ b/package.nls.json
@@ -1,6 +1,7 @@
 {
     "java.debugger.launch.projectName.description": "The preferred project in which the debugger searches for classes. There could be duplicated class names in different projects. This setting also works when the debugger looks for the specified main class when launching a program. It is required for expression evaluation.",
     "java.debugger.launch.mainClass.description": "The fully qualified class name (e.g. [java module name/]com.xyz.MainApp) or the java file path of the program entry.",
+    "java.debugger.launch.javaExec.description": "The path to java executable to use. If unset project JDK's java executable is used.",
     "java.debugger.launch.args.description": "The command line arguments passed to the program.",
     "java.debugger.launch.vmArgs.description": "The extra options and system properties for the JVM (e.g. -Xms<size> -Xmx<size> -D<name>=<value>).",
     "java.debugger.launch.modulePaths.description": "The modulepaths for launching the JVM. If not specified, the debugger will automatically resolve from current project.",

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -295,7 +295,17 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                     });
                 }
 
-                config.javaExec = await lsPlugin.resolveJavaExecutable(config.mainClass, config.projectName);
+                if (_.isEmpty(config.javaExec)) {
+                    config.javaExec = await lsPlugin.resolveJavaExecutable(config.mainClass, config.projectName);
+                } else {
+                    if (!fs.existsSync(config.javaExec)) {
+                        throw new utility.UserError({
+                            message: "Java executable file path cannot be accessed, please specify a valid path in the launch.json.",
+                            type: Type.USAGEERROR,
+                        });
+                    }
+                }
+
                 // Add the default launch options to the config.
                 config.cwd = config.cwd || _.get(folder, "uri.fsPath");
                 if (Array.isArray(config.args)) {


### PR DESCRIPTION
This new optional option will allow to specify java executable path to
use to execute the program.