### PR TITLE
Exclude **/node_modules/** from .vscode/launch.json searches

### DIFF
--- a/src/debugCodeLensProvider.ts
+++ b/src/debugCodeLensProvider.ts
@@ -181,7 +181,9 @@ async function launchJsonExists(workspace?: vscode.Uri): Promise<boolean> {
     }
 
     const workspaceFolder = vscode.workspace.getWorkspaceFolder(workspace);
-    const results: vscode.Uri[] = await vscode.workspace.findFiles(".vscode/launch.json");
+    // Excluding "**/node_modules/**" as a common cause of excessive CPU usage.
+    // https://github.com/microsoft/vscode/issues/75314#issuecomment-503195666
+    const results: vscode.Uri[] = await vscode.workspace.findFiles(".vscode/launch.json", "**/node_modules/**");
     return !!results.find((launchJson) => vscode.workspace.getWorkspaceFolder(launchJson) === workspaceFolder);
 }
 


### PR DESCRIPTION
This is a strange PR and I would have no qualms with it being rejected.

## Problem

Excluding `**/node_modules/**` from `vscode.workspace.findFiles(...)` calls is somewhat necessary to prevent excessive CPU usage when this extension is installed and users open a large frontend project in VS Code. `findFiles` searches the entire repo by default, even `.gitignore` files.

My teammates are running into this excessive CPU usage problem as they jump between frontend repos and Java repos in VS Code.

## Workaround

One comment from a VS Code member recommends extensions exclude `node_modules` since a proper fix to the `findFiles` API would be a breaking change: https://github.com/microsoft/vscode/issues/75314#issuecomment-503195666

This seems to be somewhat standard, even in extensions that have nothing to do with Node.js. For example:

- Searching `workspace.findFiles` in the `microsoft/vscode` repo shows almost every usage excluding `**/node_modules/**` explicitly. https://github.com/microsoft/vscode/search?q=workspace.findFiles
- This is the case for even the stock Markdown extension: https://github.com/microsoft/vscode/blob/c62f59fcae4d9fd029b542639f3ef58bd698f982/extensions/markdown-language-features/src/features/workspaceSymbolProvider.ts#L40

I've also PR'ed a similar change in other repos:

- https://github.com/vscode-kubernetes-tools/vscode-kubernetes-tools/pull/1041

Would this be reasonable in `vscode-java-debug` as well?

## Risks

The [docs on `workspace.findFiles(...)`](https://code.visualstudio.com/api/references/vscode-api#workspace.findFiles) say an undefined 2nd argument defaults to the user's `files.exclude` setting. Changing this argument to `**/node_modules/**` means this search no longer excludes the user configured `files.exclude`. If that's a concern, I think we can concatenate `**/node_modules/**` after looking up the `files.exclude` setting.