### PR TITLE
Only pop-up build errors notification when the errors are on the running project's classpath

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -16,7 +16,7 @@ export const JAVA_RESOLVE_MAINCLASS = "vscode.java.resolveMainClass";
 
 export const JAVA_VALIDATE_LAUNCHCONFIG = "vscode.java.validateLaunchConfig";
 
-export const JAVA_BUILD_WORKSPACE = "java.workspace.compile";
+export const JAVA_BUILD_WORKSPACE = "vscode.java.buildWorkspace";
 
 export const JAVA_EXECUTE_WORKSPACE_COMMAND = "java.execute.workspaceCommand";
 

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -248,26 +248,28 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
                     config.internalConsoleOptions = "neverOpen";
                 }
 
-                if (needsBuildWorkspace()) {
-                    progressReporter.report("Compiling...");
-                    const proceed = await buildWorkspace(progressReporter);
-                    if (!proceed) {
-                        return undefined;
-                    }
-                }
 
                 if (progressReporter.isCancelled()) {
                     return undefined;
                 }
-                if (!config.mainClass) {
-                    progressReporter.report("Resolving main class...");
-                } else {
-                    progressReporter.report("Resolving launch configuration...");
-                }
+
+                progressReporter.report("Resolving main class...");
                 const mainClassOption = await this.resolveAndValidateMainClass(folder && folder.uri, config, progressReporter);
                 if (!mainClassOption || !mainClassOption.mainClass) { // Exit silently if the user cancels the prompt fix by ESC.
                     // Exit the debug session.
                     return undefined;
+                }
+
+                if (needsBuildWorkspace()) {
+                    progressReporter.report("Compiling...");
+                    const proceed = await buildWorkspace({
+                            mainClass: mainClassOption.mainClass,
+                            projectName: mainClassOption.projectName,
+                            isFullBuild: false,
+                        }, progressReporter);
+                    if (!proceed) {
+                        return undefined;
+                    }
                 }
 
                 progressReporter.report("Resolving launch configuration...");


### PR DESCRIPTION
Fixes #1214
Requires https://github.com/microsoft/java-debug/pull/459

- For a build-tool managed project, will check if the running project and its references projects contain build errors. If so, report build failure. Otherwise, return succeed.
- For unmanaged folder, only check if the running main class contains build errors. If so, report build failure. Otherwise, return succeed.
- Add a "Always Continue" button in case users want to always continue on build failure.