### PR TITLE
Display the running launch config name in progress bar for transparency

### DIFF
--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -108,7 +108,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
             progressReporter.observe(token);
             const defaultLaunchConfig = {
                 type: "java",
-                name: "Launch Current File",
+                name: "Current File",
                 request: "launch",
                 // tslint:disable-next-line
                 mainClass: "${file}",
@@ -169,7 +169,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
     }
 
     private constructLaunchConfigName(mainClass: string, cache: { [key: string]: any }) {
-        const name = `Launch ${mainClass.substr(mainClass.lastIndexOf(".") + 1)}`;
+        const name = `${mainClass.substr(mainClass.lastIndexOf(".") + 1)}`;
         if (cache[name] === undefined) {
             cache[name] = 0;
             return name;
@@ -204,7 +204,7 @@ export class JavaDebugConfigurationProvider implements vscode.DebugConfiguration
         if (!progressReporter && config.__progressId) {
             return undefined;
         } else if (!progressReporter) {
-            progressReporter = progressProvider.createProgressReporter(config.noDebug ? "Run" : "Debug");
+            progressReporter = progressProvider.createProgressReporter(utility.launchJobName(config.name, config.noDebug));
         }
 
         progressReporter.observe(token);

--- a/src/debugCodeLensProvider.ts
+++ b/src/debugCodeLensProvider.ts
@@ -152,7 +152,7 @@ async function constructDebugConfig(mainClass: string, projectName: string, work
     if (!debugConfig) {
         debugConfig = {
             type: "java",
-            name: `Launch ${mainClass.substr(mainClass.lastIndexOf(".") + 1)}`,
+            name: `${mainClass.substr(mainClass.lastIndexOf(".") + 1)}`,
             request: "launch",
             mainClass,
             projectName,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -330,6 +330,7 @@ async function launchMain(mainMethods: IMainClassOption[], uri: vscode.Uri, noDe
         throw new utility.OperationCancelledError("");
     }
 
+    progressReporter.setJobName(utility.launchJobNameByMainClass(pick.mainClass, noDebug));
     progressReporter.report("Launching main class...");
     startDebugging(pick.mainClass, pick.projectName || "", uri, noDebug, progressReporter);
 }
@@ -366,6 +367,7 @@ async function runJavaProject(node: any, noDebug: boolean) {
             throw new utility.OperationCancelledError("");
         }
 
+        progressReporter.setJobName(utility.launchJobNameByMainClass(pick.mainClass, noDebug));
         progressReporter.report("Launching main class...");
         const projectName: string | undefined = pick.projectName;
         const mainClass: string = pick.mainClass;
@@ -379,7 +381,7 @@ async function runJavaProject(node: any, noDebug: boolean) {
         });
         const debugConfig = existConfig || {
             type: "java",
-            name: `Launch ${mainClass.substr(mainClass.lastIndexOf(".") + 1)}`,
+            name: `${mainClass.substr(mainClass.lastIndexOf(".") + 1)}`,
             request: "launch",
             mainClass,
             projectName,

--- a/src/progressAPI.ts
+++ b/src/progressAPI.ts
@@ -5,6 +5,12 @@ import { CancellationToken, ProgressLocation } from "vscode";
 
 export interface IProgressReporter {
     /**
+     * Set the job name.
+     * @param jobName the job name
+     */
+    setJobName(jobName: string): void;
+
+    /**
      * Returns the id of the progress reporter.
      */
     getId(): string;

--- a/src/progressImpl.ts
+++ b/src/progressImpl.ts
@@ -52,6 +52,10 @@ class ProgressReporter implements IProgressReporter {
         this._disposables.push(this._tokenSource);
     }
 
+    public setJobName(jobName: string): void {
+        this._jobName = jobName;
+    }
+
     public getId(): string {
         return this._id;
     }

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -313,3 +313,13 @@ function getJavaServerMode(): ServerMode {
     return vscode.workspace.getConfiguration().get("java.server.launchMode")
         || ServerMode.HYBRID;
 }
+
+export function launchJobName(configName: string, noDebug: boolean): string {
+    let jobName = noDebug ? "Run" : "Debug";
+    jobName += configName ? ` '${configName} '` : "";
+    return jobName;
+}
+
+export function launchJobNameByMainClass(mainClass: string, noDebug: boolean): string {
+    return launchJobName(mainClass.substr(mainClass.lastIndexOf(".") + 1), noDebug);
+}


### PR DESCRIPTION
**Before**: (It uses some generic message for launching notification.)
![image](https://user-images.githubusercontent.com/14052197/220277525-a18f61cb-9ce9-4ff2-bc79-4d5e2a8d355a.png)

**Now**: (It uses the running application or launch config name in notification.)
- Use the launch config name as job name if F5 is triggered.
![image](https://user-images.githubusercontent.com/14052197/220278166-b19a9484-b6d0-4f98-ae7a-4147777a92e1.png)
- Use the main class name as job name if no launch.json exists.
![image](https://user-images.githubusercontent.com/14052197/220277318-b17babc4-9743-4926-a2f6-8cb18e62e66c.png)
