### PR TITLE
Fix the error 'compareVersions is not a function'

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -312,7 +312,7 @@ async function canDelegateToJavaTestRunner(uri: vscode.Uri): Promise<boolean> {
 function launchTesting(uri: vscode.Uri, noDebug: boolean, progressReporter: IProgressReporter) {
     const command: string = noDebug ? "java.test.editor.run" : "java.test.editor.debug";
     vscode.commands.executeCommand(command, uri, progressReporter);
-    if (compareVersions(getTestExtensionVersion(), "0.26.1") <= 0) {
+    if (compareVersions.compare(getTestExtensionVersion(), "0.26.1", "<=")) {
         throw new utility.OperationCancelledError("");
     }
 }


### PR DESCRIPTION
Reproduce steps:
- Open a unit test file in VS Code
- Click the top right ▷button, the debugger will show an uncaught error as follows.
![image](https://user-images.githubusercontent.com/14052197/223327508-244ed6b0-7ebc-427d-834e-2e407b18cfde.png)
