### PR TITLE
Add context menus to Variables view to auto show 'toString()' value

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,6 +138,14 @@
       {
         "command": "java.debug.variables.notShowToString",
         "title": "Disable 'toString()' Object View"
+      },
+      {
+        "command": "java.debug.variables.autoExpandLazyVariables",
+        "title": "Auto Expand Lazy Variables"
+      },
+      {
+        "command": "java.debug.variables.manualExpandLazyVariables",
+        "title": "Manual Expand Lazy Variables"
       }
     ],
     "menus": {
@@ -295,6 +303,14 @@
         {
           "command": "java.debug.variables.notShowToString",
           "when": "false"
+        },
+        {
+          "command": "java.debug.variables.autoExpandLazyVariables",
+          "when": "false"
+        },
+        {
+          "command": "java.debug.variables.manualExpandLazyVariables",
+          "when": "false"
         }
       ],
       "debug/variables/context": [
@@ -339,14 +355,14 @@
           "group": "1_view@4"
         },
         {
-          "command": "java.debug.variables.showToString",
-          "when": "debugType == 'java' && javadebug:showToString == 'off'",
-          "group": "1_view@5"
+          "command": "java.debug.variables.autoExpandLazyVariables",
+          "when": "debugType == 'java' && javadebug:expandLazyVariable == 'off'",
+          "group": "1_view@6"
         },
         {
-          "command": "java.debug.variables.notShowToString",
-          "when": "debugType == 'java' && javadebug:showToString == 'on'",
-          "group": "1_view@5"
+          "command": "java.debug.variables.manualExpandLazyVariables",
+          "when": "debugType == 'java' && javadebug:expandLazyVariable == 'on'",
+          "group": "1_view@6"
         }
       ]
     },


### PR DESCRIPTION
This partially mitigate the issue https://github.com/microsoft/vscode-java-debug/issues/1297.

- Remove the old menus "**Enable/Disable 'toString()' Object View**"
- Instead, add new context menus "**Auto/Manual Expand Lazy Variables**" to Variables view. 
   - "Auto Expand Lazy Variables" will show the toString() value directly.
   - "Manual Expand Lazy Variables" then shows an eye icon on Object instance, and click it to expand toString value.

![lazy variables](https://user-images.githubusercontent.com/14052197/227440658-87d59ec0-1bf3-4a57-950f-510113749d35.gif)
