### PR TITLE
Provide a setting to control whether to support debugging on decompiled source

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
             "args": ["--extensionDevelopmentPath=${workspaceRoot}" ],
             "stopOnEntry": false,
             "sourceMaps": true,
-            "outFiles": [ "${workspaceRoot}/out/src/**/*.js" ],
+            "outFiles": [ "${workspaceRoot}/dist/**/*.js" ],
             "preLaunchTask": "npm: watch",
             "env": {
               "DEBUG_VSCODE_JAVA":"true"

--- a/package.json
+++ b/package.json
@@ -967,6 +967,16 @@
           "description": "%java.debugger.configuration.vmArgs.description%",
           "default": ""
         },
+        "java.debug.settings.debugSupportOnDecompiledSource": {
+          "type": "string",
+          "enum": [
+            "auto",
+            "on",
+            "off"
+          ],
+          "description": "%java.debugger.configuration.debugSupportOnDecompiledSource.description%",
+          "default": "auto"
+        },
         "java.silentNotification": {
           "type": "boolean",
           "description": "%java.debugger.configuration.silentNotification%",

--- a/package.nls.json
+++ b/package.nls.json
@@ -72,5 +72,6 @@
     "java.debugger.configuration.jdwp.requestTimeout.description": "The timeout (ms) of JDWP request when the debugger communicates with the target JVM.",
     "java.debugger.configuration.vmArgs.description": "The default VM arguments to launch the Java program. Eg. Use '-Xmx1G -ea' to increase the heap size to 1GB and enable assertions. If you want to customize the VM arguments for a specific debug session, please modify the 'vmArgs' config in launch.json.",
     "java.debugger.configuration.silentNotification": "Controls whether notifications can be used to report progress. If true, use status bar to report progress instead.",
-    "java.debugger.configuration.jdwp.async.description": "Experimental: Controls whether the debugger is allowed to send JDWP commands asynchronously. Async mode can improve remote debugging response speed on high-latency networks."
+    "java.debugger.configuration.jdwp.async.description": "Experimental: Controls whether the debugger is allowed to send JDWP commands asynchronously. Async mode can improve remote debugging response speed on high-latency networks.",
+    "java.debugger.configuration.debugSupportOnDecompiledSource.description": "[Experimental]: Enable debugging support on the decompiled source code. When set to 'auto', this feature will be automatically enabled in Visual Studio Code - Insiders. Be aware that this feature may affect the loading speed of Call Stack Viewlet."
 }

--- a/package.nls.zh-cn.json
+++ b/package.nls.zh-cn.json
@@ -69,5 +69,6 @@
     "java.debugger.configuration.jdwp.requestTimeout.description": "调试器与目标JVM通信时JDWP请求的超时时间（ms）。",
     "java.debugger.configuration.vmArgs.description": "启动Java程序的默认VM参数。例如，使用'-Xmx1G -ea'将堆大小增加到1GB并启用断言。如果要为特定的调试会话定制VM参数，请修改launch.json中的'vmArgs'配置。",
     "java.debugger.configuration.silentNotification": "控制是否可以使用通知来报告进度。如果为真，则使用状态栏来报告进度。",
-    "java.debugger.configuration.jdwp.async.description": "实验性的：控制是否允许调试器以异步方式发送JDWP命令。异步模式可以提高高延迟网络上的远程调试响应速度。"
+    "java.debugger.configuration.jdwp.async.description": "实验性的：控制是否允许调试器以异步方式发送JDWP命令。异步模式可以提高高延迟网络上的远程调试响应速度。",
+    "java.debugger.configuration.debugSupportOnDecompiledSource.description": "[实验性的]: 在反编译的源代码上启用调试支持。当设置为'auto'时，该功能将在Visual Studio Code - Insiders中自动启用。请注意，该功能可能会影响Call Stack试图的加载速度。"
 }

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -22,6 +22,7 @@ import { resolveJavaProcess } from "./processPicker";
 import { IProgressReporter } from "./progressAPI";
 import { progressProvider } from "./progressImpl";
 import * as utility from "./utility";
+import { version } from "vscode";
 
 const platformNameMappings: { [key: string]: string } = {
     win32: "windows",
@@ -785,6 +786,10 @@ async function updateDebugSettings(event?: vscode.ConfigurationChangeEvent) {
             };
 
             const asyncJDWP: string = debugSettingsRoot.settings.jdwp.async;
+            let debugSupportOnDecompiledSource: string = debugSettingsRoot.settings.debugSupportOnDecompiledSource;
+            if (debugSupportOnDecompiledSource === 'auto') {
+                debugSupportOnDecompiledSource = version.includes("insider") ? "on" : "off";
+            }
             const settings = await commands.executeJavaLanguageServerCommand(commands.JAVA_UPDATE_DEBUG_SETTINGS, JSON.stringify(
                 {
                     ...debugSettingsRoot.settings,
@@ -799,6 +804,7 @@ async function updateDebugSettings(event?: vscode.ConfigurationChangeEvent) {
                     limitOfVariablesPerJdwpRequest: Math.max(debugSettingsRoot.settings.jdwp.limitOfVariablesPerJdwpRequest, 1),
                     jdwpRequestTimeout: Math.max(debugSettingsRoot.settings.jdwp.requestTimeout, 100),
                     asyncJDWP,
+                    debugSupportOnDecompiledSource,
                 }));
             if (logLevel === "FINE") {
                 // tslint:disable-next-line:no-console

--- a/src/configurationProvider.ts
+++ b/src/configurationProvider.ts
@@ -22,7 +22,6 @@ import { resolveJavaProcess } from "./processPicker";
 import { IProgressReporter } from "./progressAPI";
 import { progressProvider } from "./progressImpl";
 import * as utility from "./utility";
-import { version } from "vscode";
 
 const platformNameMappings: { [key: string]: string } = {
     win32: "windows",
@@ -788,7 +787,7 @@ async function updateDebugSettings(event?: vscode.ConfigurationChangeEvent) {
             const asyncJDWP: string = debugSettingsRoot.settings.jdwp.async;
             let debugSupportOnDecompiledSource: string = debugSettingsRoot.settings.debugSupportOnDecompiledSource;
             if (debugSupportOnDecompiledSource === 'auto') {
-                debugSupportOnDecompiledSource = version.includes("insider") ? "on" : "off";
+                debugSupportOnDecompiledSource = vscode.version.includes("insider") ? "on" : "off";
             }
             const settings = await commands.executeJavaLanguageServerCommand(commands.JAVA_UPDATE_DEBUG_SETTINGS, JSON.stringify(
                 {


### PR DESCRIPTION
This requires https://github.com/microsoft/java-debug/pull/495.

Add new setting `java.debug.settings.debugSupportOnDecompiledSource` to control whether to enable debugging support on the decompiled source code.
- `auto` - When set to 'auto', this feature will be automatically enabled in Visual Studio Code - Insiders.
- `on`
- `off`