### PR TITLE
Subscribe to Java extension's SourceInvalidatedEvent and refresh the stack frames if they used the affected source

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,7 +99,7 @@ async function subscribeToJavaExtensionEvents(): Promise<void> {
     // wait javaExt to activate
     const timeout = 30 * 60 * 1000; // wait 30 min at most
     let count = 0;
-    while(!javaExt.isActive && count < timeout) {
+    while (!javaExt.isActive && count < timeout) {
        await delay(1000);
        count += 1000;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -26,6 +26,7 @@ import { JavaTerminalLinkProvder } from "./terminalLinkProvider";
 import { initializeThreadOperations } from "./threadOperations";
 import * as utility from "./utility";
 import { registerVariableMenuCommands } from "./variableMenu";
+import { promisify } from "util";
 
 export async function activate(context: vscode.ExtensionContext): Promise<any> {
     await initializeFromJsonFile(context.asAbsolutePath("./package.json"), {
@@ -75,6 +76,7 @@ function initializeExtension(_operationId: string, context: vscode.ExtensionCont
     initializeHotCodeReplace(context);
     initializeCodeLensProvider(context);
     initializeThreadOperations(context);
+    subscribeToJavaExtensionEvents();
 
     context.subscriptions.push(vscode.languages.registerInlineValuesProvider("java", new JavaInlineValuesProvider()));
     return {
@@ -85,6 +87,35 @@ function initializeExtension(_operationId: string, context: vscode.ExtensionCont
 // this method is called when your extension is deactivated
 export async function deactivate() {
     await disposeTelemetryWrapper();
+}
+
+const delay = promisify(setTimeout);
+async function subscribeToJavaExtensionEvents(): Promise<void> {
+    const javaExt = vscode.extensions.getExtension("redhat.java");
+    if (!javaExt) {
+       return;
+    }
+
+    // wait javaExt to activate
+    const timeout = 30 * 60 * 1000; // wait 30 min at most
+    let count = 0;
+    while(!javaExt.isActive && count < timeout) {
+       await delay(1000);
+       count += 1000;
+    }
+
+    if (javaExt.isActive) {
+        javaExt.exports?.onDidSourceInvalidate?.((event: any) => {
+            if (event?.affectedRootPaths?.length) {
+                const activeDebugSession = vscode.debug.activeDebugSession;
+                if (activeDebugSession?.type === "java") {
+                    activeDebugSession.customRequest("refreshFrames", {
+                        affectedRootPaths: event.affectedRootPaths,
+                    });
+                }
+            }
+        });
+    }
 }
 
 function registerDebugEventListener(context: vscode.ExtensionContext) {


### PR DESCRIPTION
requires https://github.com/microsoft/java-debug/pull/501