### PR TITLE
fix: correctly parse `ps` output on linux

### DIFF
--- a/src/processTree.ts
+++ b/src/processTree.ts
@@ -148,10 +148,8 @@ export function getProcesses(one: (pid: number, ppid: number, command: string, a
 				// binaries with spaces in path may not work
 				// possible solution to read directly from /proc
 				let pos = fullCommand.indexOf(shortName);
-				const commandEndPosition = fullCommand.indexOf(" ", pos + shortName.length)
-				if (commandEndPosition < 0) {
-					return;
-				}
+				const commandEndPositionMaybe = fullCommand.indexOf(" ", pos + shortName.length)
+                const commandEndPosition = commandEndPositionMaybe < 0 ? fullCommand.length : commandEndPositionMaybe;
 
 				const command = fullCommand.substring(0, commandEndPosition)
 				const args = fullCommand.substring(commandEndPosition).trimStart()

--- a/src/processTree.ts
+++ b/src/processTree.ts
@@ -4,7 +4,7 @@
  *
  *  Copied from https://github.com/microsoft/vscode-node-debug/blob/master/src/node/extension/processTree.ts
  *--------------------------------------------------------------------------------------------*/
-
+/* tslint:disable */
 'use strict';
 
 import { spawn, ChildProcessWithoutNullStreams } from 'child_process';

--- a/src/processTree.ts
+++ b/src/processTree.ts
@@ -136,14 +136,19 @@ export function getProcesses(one: (pid: number, ppid: number, command: string, a
 				const shortName = substr(line, 14, 20).trim()
 				const fullCommand = substr(line, 35)
 
-				// binaries with spaces in path may not work
-				// possible solution to read directly from /proc
-				let pos = fullCommand.indexOf(shortName);
-				const commandEndPositionMaybe = fullCommand.indexOf(" ", pos + shortName.length)
-				const commandEndPosition = commandEndPositionMaybe < 0 ? fullCommand.length : commandEndPositionMaybe;
+				let command = shortName;
+				let args = fullCommand;
 
-				const command = fullCommand.substring(0, commandEndPosition)
-				const args = fullCommand.substring(commandEndPosition).trimStart()
+				const pos = fullCommand.indexOf(shortName);
+				if (pos >= 0) {
+					// binaries with spaces in path may not work
+					// possible solution to read directly from /proc
+					const commandEndPositionMaybe = fullCommand.indexOf(" ", pos + shortName.length);
+					const commandEndPosition = commandEndPositionMaybe < 0 ? fullCommand.length : commandEndPositionMaybe;
+					command = fullCommand.substring(0, commandEndPosition)
+					args = fullCommand.substring(commandEndPosition).trimStart()
+				}
+
 
 				if (!isNaN(pid) && !isNaN(ppid)) {
 					one(pid, ppid, command, args);


### PR DESCRIPTION
Fixes #1388 

The issue was that `ps`'s output was parsed by hardcoded indexes. The parsing function had been written three years ago. Obviously, ps output format has slightly changed. So I have written regex to parse it more in more flexible fashion. Tested on mine machine. Works grate