### PR TITLE
Fix the permission issue of no-response bot

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -14,8 +14,10 @@ on:
 jobs:
   noResponse:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
-      - uses: lee-dohm/no-response@v0.5.0
+      - uses: lee-dohm/no-response@9bb0a4b5e6a45046f00353d5de7d90fb8bd773bb #v0.5.0
         with:
           token: ${{ github.token }}
           daysUntilClose: 14 # Number of days of inactivity before an Issue is closed for lack of response


### PR DESCRIPTION
This org has transitioned to a read-only GITHUB_TOKEN for GitHub Action workflows. This does break your builds. See https://aka.ms/github-token-perms-changes for how to resolve.
