### PR TITLE
fix: fix java_tool_option in same terminal

### DIFF
--- a/bundled/scripts/noConfigScripts/debugjava
+++ b/bundled/scripts/noConfigScripts/debugjava
@@ -2,15 +2,11 @@
 # Java No-Config Debug Wrapper Script for Unix/Linux/macOS
 # This script intercepts java commands and automatically enables JDWP debugging
 
-# Export the endpoint file path for JDWP port communication
-export JDWP_ADAPTER_ENDPOINTS=$VSCODE_JDWP_ADAPTER_ENDPOINTS
-
-# Set JDWP options only for this debugjava invocation
-# This overrides the global JAVA_TOOL_OPTIONS to avoid affecting other Java processes
-export JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0"
-
 # Get the directory of this script
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# Use Node.js wrapper to capture JDWP port
+# Set environment variables only for the node process, not the current shell
+# This ensures JAVA_TOOL_OPTIONS doesn't affect subsequent commands in the terminal
+JDWP_ADAPTER_ENDPOINTS=$VSCODE_JDWP_ADAPTER_ENDPOINTS \
+JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0" \
 exec node "$SCRIPT_DIR/jdwp-wrapper.js" "$@"

--- a/bundled/scripts/noConfigScripts/debugjava.bat
+++ b/bundled/scripts/noConfigScripts/debugjava.bat
@@ -2,6 +2,9 @@
 REM Java No-Config Debug Wrapper Script for Windows
 REM This script intercepts java commands and automatically enables JDWP debugging
 
+REM Use setlocal to ensure environment variables don't persist after this script exits
+setlocal
+
 REM Export the endpoint file path for JDWP port communication
 set JDWP_ADAPTER_ENDPOINTS=%VSCODE_JDWP_ADAPTER_ENDPOINTS%
 
@@ -11,3 +14,6 @@ set JAVA_TOOL_OPTIONS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,addr
 
 REM Use Node.js wrapper to capture JDWP port
 node "%~dp0jdwp-wrapper.js" %*
+
+REM endlocal is implicit at script exit, but we can call it explicitly for clarity
+endlocal

--- a/bundled/scripts/noConfigScripts/debugjava.fish
+++ b/bundled/scripts/noConfigScripts/debugjava.fish
@@ -2,15 +2,11 @@
 # Java No-Config Debug Wrapper Script for Fish Shell
 # This script intercepts java commands and automatically enables JDWP debugging
 
-# Export the endpoint file path for JDWP port communication
-set -x JDWP_ADAPTER_ENDPOINTS $VSCODE_JDWP_ADAPTER_ENDPOINTS
-
-# Set JDWP options only for this debugjava invocation
-# This overrides the global JAVA_TOOL_OPTIONS to avoid affecting other Java processes
-set -x JAVA_TOOL_OPTIONS "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0"
-
 # Get the directory of this script
 set script_dir (dirname (status -f))
 
-# Use Node.js wrapper to capture JDWP port
-exec node "$script_dir/jdwp-wrapper.js" $argv
+# Set environment variables only for the node process, not the current shell
+# This ensures JAVA_TOOL_OPTIONS doesn't affect subsequent commands in the terminal
+env JDWP_ADAPTER_ENDPOINTS=$VSCODE_JDWP_ADAPTER_ENDPOINTS \
+    JAVA_TOOL_OPTIONS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0" \
+    node "$script_dir/jdwp-wrapper.js" $argv

--- a/bundled/scripts/noConfigScripts/debugjava.ps1
+++ b/bundled/scripts/noConfigScripts/debugjava.ps1
@@ -1,15 +1,32 @@
 # Java No-Config Debug Wrapper Script for PowerShell
 # This script intercepts java commands and automatically enables JDWP debugging
 
-# Export the endpoint file path for JDWP port communication
-$env:JDWP_ADAPTER_ENDPOINTS = $env:VSCODE_JDWP_ADAPTER_ENDPOINTS
-
-# Set JDWP options only for this debugjava invocation
-# This overrides the global JAVA_TOOL_OPTIONS to avoid affecting other Java processes
-$env:JAVA_TOOL_OPTIONS = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0"
-
 # Get the directory of this script
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
 
-# Use Node.js wrapper to capture JDWP port
-& node (Join-Path $scriptDir "jdwp-wrapper.js") $args
+# Save current environment variables to restore later
+$oldJavaToolOptions = $env:JAVA_TOOL_OPTIONS
+$oldJdwpAdapterEndpoints = $env:JDWP_ADAPTER_ENDPOINTS
+
+try {
+    # Set environment variables only for this debugjava invocation
+    $env:JDWP_ADAPTER_ENDPOINTS = $env:VSCODE_JDWP_ADAPTER_ENDPOINTS
+    $env:JAVA_TOOL_OPTIONS = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=0"
+
+    # Use Node.js wrapper to capture JDWP port
+    & node (Join-Path $scriptDir "jdwp-wrapper.js") $args
+}
+finally {
+    # Restore original environment variables to avoid affecting subsequent commands
+    if ($null -eq $oldJavaToolOptions) {
+        Remove-Item Env:\JAVA_TOOL_OPTIONS -ErrorAction SilentlyContinue
+    } else {
+        $env:JAVA_TOOL_OPTIONS = $oldJavaToolOptions
+    }
+    
+    if ($null -eq $oldJdwpAdapterEndpoints) {
+        Remove-Item Env:\JDWP_ADAPTER_ENDPOINTS -ErrorAction SilentlyContinue
+    } else {
+        $env:JDWP_ADAPTER_ENDPOINTS = $oldJdwpAdapterEndpoints
+    }
+}


### PR DESCRIPTION
This PR fix the `JAVA_TOOL_OPTION` injection in the sample terminal.
This fix is start a child process with `JAVA_TOOL_OPTION` to avoid such issue