### PR TITLE
Bump version to 0.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to the "vscode-java-debugger" extension will be documented i
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.59.0 - 2026-04-09
+### Added
+- Support pause all threads when hit breakpoints. [#1603](https://github.com/microsoft/vscode-java-debug/pull/1603).
+- Support suspend all setting. [java-debug#619](https://github.com/microsoft/java-debug/pull/619).
+
+### Changed
+- Provide graceful shutdown on debug stop action. [java-debug#620](https://github.com/microsoft/java-debug/pull/620).
+
+### Fixed
+- Use JDTUtils.toUri() for decompiled class file URIs. [java-debug#624](https://github.com/microsoft/java-debug/pull/624).
+- Handle NoSuchMethodError for isMainMethodCandidate() on older JDT. [java-debug#622](https://github.com/microsoft/java-debug/pull/622).
+- Exclude Map.Entry from lazy loading to show key:value inline. [java-debug#621](https://github.com/microsoft/java-debug/pull/621).
+
 ## 0.58.5 - 2026-01-06
 ### Fixed
 - Fix `lspFrame.source.path` is null. [java-debug#618](https://github.com/microsoft/java-debug/pull/618).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vscode-java-debug",
-  "version": "0.58.5",
+  "version": "0.59.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "vscode-java-debug",
-      "version": "0.58.5",
+      "version": "0.59.0",
       "license": "SEE LICENSE IN LICENSE.txt",
       "dependencies": {
         "compare-versions": "^4.1.4",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-java-debug",
   "displayName": "Debugger for Java",
   "description": "A lightweight Java debugger for Visual Studio Code",
-  "version": "0.58.5",
+  "version": "0.59.0",
   "publisher": "vscjava",
   "preview": false,
   "aiKey": "67d4461e-ccba-418e-8082-1bd0acfe8516",


### PR DESCRIPTION
Bump version to 0.59.0 and update CHANGELOG.

## Changes included in this release

### Added
- Support pause all threads when hit breakpoints (#1603)
- Support suspend all setting (java-debug#619)

### Changed
- Provide graceful shutdown on debug stop action (java-debug#620)

### Fixed
- Use JDTUtils.toUri() for decompiled class file URIs (java-debug#624)
- Handle NoSuchMethodError for isMainMethodCandidate() on older JDT (java-debug#622)
- Exclude Map.Entry from lazy loading to show key:value inline (java-debug#621)