### PR TITLE
Fix Azure CI by specifying Node.js 20.x version

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -49,6 +49,10 @@ extends:
                   versionSpec: "21"
                   jdkArchitectureOption: x64
                   jdkSourceOption: PreInstalled
+              - task: NodeTool@0
+                displayName: Use Node 20.x
+                inputs:
+                  versionSpec: 20.x
               - task: Npm@1
                 displayName: npm install
                 inputs:


### PR DESCRIPTION
## Problem

The Azure CI pipeline (ci.yml) vsce package step was failing with:

```
ReferenceError: File is not defined
    at undici/lib/web/webidl/index.js:537
```

## Root Cause

ci.yml did not specify a Node.js version, relying on the pre-installed version on the 1ES_JavaTooling_Ubuntu-2004 image (likely Node 18.x). The latest @vscode/vsce pulls in undici, which uses the File global API - only available in Node.js 20+.

Other Azure pipelines (nightly.yml, rc.yml) and the GitHub workflow (build.yml) already specify Node 20.x. Only ci.yml was missing it.

## Fix

Add NodeTool@0 task with versionSpec 20.x before npm install, consistent with all other pipelines.
