### PR TITLE
Update telemetry wrapper to 0.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "dotenv": "^16.4.5",
         "lodash": "^4.18.0",
         "uuid": "^8.3.2",
-        "vscode-extension-telemetry-wrapper": "^0.14.0",
+        "vscode-extension-telemetry-wrapper": "^0.15.1",
         "vscode-languageclient": "6.0.0-next.9",
         "vscode-languageserver-types": "3.16.0",
         "vscode-tas-client": "^0.1.84"
@@ -115,68 +115,57 @@
       }
     },
     "node_modules/@microsoft/1ds-core-js": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.3.4.tgz",
-      "integrity": "sha512-3gbDUQgAO8EoyQTNcAEkxpuPnioC0May13P1l1l0NKZ128L9Ts/sj8QsfwCRTjHz0HThlA+4FptcAJXNYUy3rg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.4.1.tgz",
+      "integrity": "sha512-utqwacfUkiGJROn4WC7aNdRBsRxwhNWXuqaJM2B0N0WHmv1+IhSuI7RQ3FHwxRP1dxZi/xn9aELMZ7HMStsW1w==",
+      "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-core-js": "3.3.4",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "node_modules/@microsoft/1ds-post-js": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.3.4.tgz",
-      "integrity": "sha512-nlKjWricDj0Tn68Dt0P8lX9a+X7LYrqJ6/iSfQwMfDhRIGLqW+wxx8gxS+iGWC/oc8zMQAeiZaemUpCwQcwpRQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.4.1.tgz",
+      "integrity": "sha512-CkFEhDY7X8E2JLr6HsEvRiC0DaLOCsA7vlbq/9DJP65gAumgw2NnFNIAOg6Je5Geq1LDu76/nb2hP34p8eGggw==",
+      "license": "MIT",
       "dependencies": {
-        "@microsoft/1ds-core-js": "4.3.4",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "node_modules/@microsoft/applicationinsights-channel-js": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.3.4.tgz",
-      "integrity": "sha512-Z4nrxYwGKP9iyrYtm7iPQXVOFy4FsEsX0nDKkAi96Qpgw+vEh6NH4ORxMMuES0EollBQ3faJyvYCwckuCVIj0g==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.4.1.tgz",
+      "integrity": "sha512-QS1k6iwVwR1MznGAB1H0F9raqpevbFNbadLS5O1419pz9OEWBfF9wRQLnENCyo8QS9Q0IdiqnGAON/D8IywpWg==",
+      "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-common": "3.3.4",
-        "@microsoft/applicationinsights-core-js": "3.3.4",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
-      },
-      "peerDependencies": {
-        "tslib": ">= 1.0.0"
-      }
-    },
-    "node_modules/@microsoft/applicationinsights-common": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.3.4.tgz",
-      "integrity": "sha512-4ms16MlIvcP4WiUPqopifNxcWCcrXQJ2ADAK/75uok2mNQe6ZNRsqb/P+pvhUxc8A5HRlvoXPP1ptDSN5Girgw==",
-      "dependencies": {
-        "@microsoft/applicationinsights-core-js": "3.3.4",
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       },
       "peerDependencies": {
         "tslib": ">= 1.0.0"
       }
     },
     "node_modules/@microsoft/applicationinsights-core-js": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.3.4.tgz",
-      "integrity": "sha512-MummANF0mgKIkdvVvfmHQTBliK114IZLRhTL0X0Ep+zjDwWMHqYZgew0nlFKAl6ggu42abPZFK5afpE7qjtYJA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
+      "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
+      "license": "MIT",
       "dependencies": {
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       },
       "peerDependencies": {
         "tslib": ">= 1.0.0"
@@ -186,22 +175,23 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
       "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+      "license": "MIT",
       "dependencies": {
         "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
       }
     },
     "node_modules/@microsoft/applicationinsights-web-basic": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.3.4.tgz",
-      "integrity": "sha512-OpEPXr8vU/t/M8T9jvWJzJx/pCyygIiR1nGM/2PTde0wn7anl71Gxl5fWol7K/WwFEORNjkL3CEyWOyDc+28AA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.4.1.tgz",
+      "integrity": "sha512-V/hSlauFp1thJa57+TMv5mAYinJAQUi4zOmDmpahnDgs8g1zrQ0D8QYDmu0Zfi+9GhoD80B4yJez2+ydJPJz2w==",
+      "license": "MIT",
       "dependencies": {
-        "@microsoft/applicationinsights-channel-js": "3.3.4",
-        "@microsoft/applicationinsights-common": "3.3.4",
-        "@microsoft/applicationinsights-core-js": "3.3.4",
+        "@microsoft/applicationinsights-channel-js": "3.4.1",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       },
       "peerDependencies": {
         "tslib": ">= 1.0.0"
@@ -211,22 +201,25 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.3.tgz",
       "integrity": "sha512-JTWTU80rMy3mdxOjjpaiDQsTLZ6YSGGqsjURsY6AUQtIj0udlF/jYmhdLZu8693ZIC0T1IwYnFa0+QeiMnziBA==",
+      "license": "MIT",
       "dependencies": {
         "@nevware21/ts-utils": ">= 0.10.4 < 2.x"
       }
     },
     "node_modules/@nevware21/ts-async": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.3.tgz",
-      "integrity": "sha512-UsF7eerLsVfid7iV1oXF80qXBwHNBeqSqfh/nPZgirRU1MACmSsj83EZKS2ViFHVfSGG6WIuXMGBP6KciXfYhA==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.5.tgz",
+      "integrity": "sha512-vwqaL05iJPjLeh5igPi8MeeAu10i+Aq7xko1fbo9F5Si6MnVN5505qaV7AhSdk5MCBJVT/UYMk3kgInNjDb4Ig==",
+      "license": "MIT",
       "dependencies": {
-        "@nevware21/ts-utils": ">= 0.11.5 < 2.x"
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x"
       }
     },
     "node_modules/@nevware21/ts-utils": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.11.5.tgz",
-      "integrity": "sha512-7nIzWKR50mf3htOg53kwPLqD5iJaRfVyBvb1NJhlIncyP1WzK8vAQbU9rqIsRtv7td1CnqspdP6IWNEjOjaeug=="
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.13.0.tgz",
+      "integrity": "sha512-F3mD+DsUn9OiZmZc5tg0oKqrJCtiCstwx+wE+DNzFYh2cCRUuzTYdK9zGGP/au2BWvbOQ6Tqlbjr2+dT1P3AlQ==",
+      "license": "MIT"
     },
     "node_modules/@types/eslint": {
       "version": "9.6.1",
@@ -308,13 +301,14 @@
       "license": "MIT"
     },
     "node_modules/@vscode/extension-telemetry": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.9.7.tgz",
-      "integrity": "sha512-2GQbcfDUTg0QC1v0HefkHNwYrE5LYKzS3Zb0+uA6Qn1MBDzgiSh23ddOZF/JRqhqBFOG0mE70XslKSGQ5v9KwQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-1.5.1.tgz",
+      "integrity": "sha512-rnRRQIRCwRdbcQ0QV5ajKJRz8noEIoQA2hX9VjAlVAVB85+ClbaPNhljobFXgW31ue69FRO6KPE4XJ/lLgKt/Q==",
+      "license": "MIT",
       "dependencies": {
-        "@microsoft/1ds-core-js": "^4.3.0",
-        "@microsoft/1ds-post-js": "^4.3.0",
-        "@microsoft/applicationinsights-web-basic": "^3.3.0"
+        "@microsoft/1ds-core-js": "^4.3.10",
+        "@microsoft/1ds-post-js": "^4.3.10",
+        "@microsoft/applicationinsights-web-basic": "^3.3.10"
       },
       "engines": {
         "vscode": "^1.75.0"
@@ -2892,12 +2886,12 @@
       }
     },
     "node_modules/vscode-extension-telemetry-wrapper": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.14.0.tgz",
-      "integrity": "sha512-EYr1hqiYVSGfupchDN405zSwuvA8V3tJ62KcLIRDr/4ongOc2AvSZ0BlRq8a0w950tadsMlXTKEheB97fZBttg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.15.1.tgz",
+      "integrity": "sha512-LrGNdWxENFbrhNwxKKznEzoNndM6wVJTCRFP+jWjwCzZbmsBRUhkwaEIbDD3fIEdmdrMHTW5bjN7OWUa79RGPQ==",
+      "license": "MIT",
       "dependencies": {
-        "@vscode/extension-telemetry": "^0.9.6",
-        "uuid": "^8.3.2"
+        "@vscode/extension-telemetry": "^1.2.0"
       }
     },
     "node_modules/vscode-jsonrpc": {
@@ -3361,62 +3355,50 @@
       }
     },
     "@microsoft/1ds-core-js": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.3.4.tgz",
-      "integrity": "sha512-3gbDUQgAO8EoyQTNcAEkxpuPnioC0May13P1l1l0NKZ128L9Ts/sj8QsfwCRTjHz0HThlA+4FptcAJXNYUy3rg==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-core-js/-/1ds-core-js-4.4.1.tgz",
+      "integrity": "sha512-utqwacfUkiGJROn4WC7aNdRBsRxwhNWXuqaJM2B0N0WHmv1+IhSuI7RQ3FHwxRP1dxZi/xn9aELMZ7HMStsW1w==",
       "requires": {
-        "@microsoft/applicationinsights-core-js": "3.3.4",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "@microsoft/1ds-post-js": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.3.4.tgz",
-      "integrity": "sha512-nlKjWricDj0Tn68Dt0P8lX9a+X7LYrqJ6/iSfQwMfDhRIGLqW+wxx8gxS+iGWC/oc8zMQAeiZaemUpCwQcwpRQ==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/1ds-post-js/-/1ds-post-js-4.4.1.tgz",
+      "integrity": "sha512-CkFEhDY7X8E2JLr6HsEvRiC0DaLOCsA7vlbq/9DJP65gAumgw2NnFNIAOg6Je5Geq1LDu76/nb2hP34p8eGggw==",
       "requires": {
-        "@microsoft/1ds-core-js": "4.3.4",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "@microsoft/applicationinsights-channel-js": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.3.4.tgz",
-      "integrity": "sha512-Z4nrxYwGKP9iyrYtm7iPQXVOFy4FsEsX0nDKkAi96Qpgw+vEh6NH4ORxMMuES0EollBQ3faJyvYCwckuCVIj0g==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.4.1.tgz",
+      "integrity": "sha512-QS1k6iwVwR1MznGAB1H0F9raqpevbFNbadLS5O1419pz9OEWBfF9wRQLnENCyo8QS9Q0IdiqnGAON/D8IywpWg==",
       "requires": {
-        "@microsoft/applicationinsights-common": "3.3.4",
-        "@microsoft/applicationinsights-core-js": "3.3.4",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
-      }
-    },
-    "@microsoft/applicationinsights-common": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.3.4.tgz",
-      "integrity": "sha512-4ms16MlIvcP4WiUPqopifNxcWCcrXQJ2ADAK/75uok2mNQe6ZNRsqb/P+pvhUxc8A5HRlvoXPP1ptDSN5Girgw==",
-      "requires": {
-        "@microsoft/applicationinsights-core-js": "3.3.4",
-        "@microsoft/applicationinsights-shims": "3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "@microsoft/applicationinsights-core-js": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.3.4.tgz",
-      "integrity": "sha512-MummANF0mgKIkdvVvfmHQTBliK114IZLRhTL0X0Ep+zjDwWMHqYZgew0nlFKAl6ggu42abPZFK5afpE7qjtYJA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
+      "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
       "requires": {
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "@microsoft/applicationinsights-shims": {
@@ -3428,17 +3410,16 @@
       }
     },
     "@microsoft/applicationinsights-web-basic": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.3.4.tgz",
-      "integrity": "sha512-OpEPXr8vU/t/M8T9jvWJzJx/pCyygIiR1nGM/2PTde0wn7anl71Gxl5fWol7K/WwFEORNjkL3CEyWOyDc+28AA==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web-basic/-/applicationinsights-web-basic-3.4.1.tgz",
+      "integrity": "sha512-V/hSlauFp1thJa57+TMv5mAYinJAQUi4zOmDmpahnDgs8g1zrQ0D8QYDmu0Zfi+9GhoD80B4yJez2+ydJPJz2w==",
       "requires": {
-        "@microsoft/applicationinsights-channel-js": "3.3.4",
-        "@microsoft/applicationinsights-common": "3.3.4",
-        "@microsoft/applicationinsights-core-js": "3.3.4",
+        "@microsoft/applicationinsights-channel-js": "3.4.1",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-async": ">= 0.5.2 < 2.x",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
     "@microsoft/dynamicproto-js": {
@@ -3450,17 +3431,17 @@
       }
     },
     "@nevware21/ts-async": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.3.tgz",
-      "integrity": "sha512-UsF7eerLsVfid7iV1oXF80qXBwHNBeqSqfh/nPZgirRU1MACmSsj83EZKS2ViFHVfSGG6WIuXMGBP6KciXfYhA==",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.5.tgz",
+      "integrity": "sha512-vwqaL05iJPjLeh5igPi8MeeAu10i+Aq7xko1fbo9F5Si6MnVN5505qaV7AhSdk5MCBJVT/UYMk3kgInNjDb4Ig==",
       "requires": {
-        "@nevware21/ts-utils": ">= 0.11.5 < 2.x"
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x"
       }
     },
     "@nevware21/ts-utils": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.11.5.tgz",
-      "integrity": "sha512-7nIzWKR50mf3htOg53kwPLqD5iJaRfVyBvb1NJhlIncyP1WzK8vAQbU9rqIsRtv7td1CnqspdP6IWNEjOjaeug=="
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.13.0.tgz",
+      "integrity": "sha512-F3mD+DsUn9OiZmZc5tg0oKqrJCtiCstwx+wE+DNzFYh2cCRUuzTYdK9zGGP/au2BWvbOQ6Tqlbjr2+dT1P3AlQ=="
     },
     "@types/eslint": {
       "version": "9.6.1",
@@ -3541,13 +3522,13 @@
       "dev": true
     },
     "@vscode/extension-telemetry": {
-      "version": "0.9.7",
-      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-0.9.7.tgz",
-      "integrity": "sha512-2GQbcfDUTg0QC1v0HefkHNwYrE5LYKzS3Zb0+uA6Qn1MBDzgiSh23ddOZF/JRqhqBFOG0mE70XslKSGQ5v9KwQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@vscode/extension-telemetry/-/extension-telemetry-1.5.1.tgz",
+      "integrity": "sha512-rnRRQIRCwRdbcQ0QV5ajKJRz8noEIoQA2hX9VjAlVAVB85+ClbaPNhljobFXgW31ue69FRO6KPE4XJ/lLgKt/Q==",
       "requires": {
-        "@microsoft/1ds-core-js": "^4.3.0",
-        "@microsoft/1ds-post-js": "^4.3.0",
-        "@microsoft/applicationinsights-web-basic": "^3.3.0"
+        "@microsoft/1ds-core-js": "^4.3.10",
+        "@microsoft/1ds-post-js": "^4.3.10",
+        "@microsoft/applicationinsights-web-basic": "^3.3.10"
       }
     },
     "@vscode/test-electron": {
@@ -5387,12 +5368,11 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vscode-extension-telemetry-wrapper": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.14.0.tgz",
-      "integrity": "sha512-EYr1hqiYVSGfupchDN405zSwuvA8V3tJ62KcLIRDr/4ongOc2AvSZ0BlRq8a0w950tadsMlXTKEheB97fZBttg==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.15.1.tgz",
+      "integrity": "sha512-LrGNdWxENFbrhNwxKKznEzoNndM6wVJTCRFP+jWjwCzZbmsBRUhkwaEIbDD3fIEdmdrMHTW5bjN7OWUa79RGPQ==",
       "requires": {
-        "@vscode/extension-telemetry": "^0.9.6",
-        "uuid": "^8.3.2"
+        "@vscode/extension-telemetry": "^1.2.0"
       }
     },
     "vscode-jsonrpc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "dotenv": "^16.4.5",
         "lodash": "^4.18.0",
         "uuid": "^8.3.2",
-        "vscode-extension-telemetry-wrapper": "^0.15.1",
+        "vscode-extension-telemetry-wrapper": "^0.15.2",
         "vscode-languageclient": "6.0.0-next.9",
         "vscode-languageserver-types": "3.16.0",
         "vscode-tas-client": "^0.1.84"
@@ -150,6 +150,21 @@
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-common": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.4.1.tgz",
+      "integrity": "sha512-CTbD0g/68tiv2yCItsodDQBYxyHdfQkG7VhvVU8OHenukpl/7W4wEuxZuOntqhv5m9Nx/DFncbz+T83nvYTG3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       },
       "peerDependencies": {
@@ -2886,11 +2901,12 @@
       }
     },
     "node_modules/vscode-extension-telemetry-wrapper": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.15.1.tgz",
-      "integrity": "sha512-LrGNdWxENFbrhNwxKKznEzoNndM6wVJTCRFP+jWjwCzZbmsBRUhkwaEIbDD3fIEdmdrMHTW5bjN7OWUa79RGPQ==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.15.2.tgz",
+      "integrity": "sha512-efKkHF8c4kTKyBhBH2k0bZU4drqIic2jBYw/j1ixKOEEsa/WIiuUsdrBPD5uaRIoZ/91GzNCLiiV4ckIrf581g==",
       "license": "MIT",
       "dependencies": {
+        "@microsoft/applicationinsights-common": "^3.4.1",
         "@vscode/extension-telemetry": "^1.2.0"
       }
     },
@@ -3387,6 +3403,17 @@
         "@microsoft/applicationinsights-shims": "3.0.1",
         "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      }
+    },
+    "@microsoft/applicationinsights-common": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-common/-/applicationinsights-common-3.4.1.tgz",
+      "integrity": "sha512-CTbD0g/68tiv2yCItsodDQBYxyHdfQkG7VhvVU8OHenukpl/7W4wEuxZuOntqhv5m9Nx/DFncbz+T83nvYTG3g==",
+      "requires": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
         "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
       }
     },
@@ -5368,10 +5395,11 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vscode-extension-telemetry-wrapper": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.15.1.tgz",
-      "integrity": "sha512-LrGNdWxENFbrhNwxKKznEzoNndM6wVJTCRFP+jWjwCzZbmsBRUhkwaEIbDD3fIEdmdrMHTW5bjN7OWUa79RGPQ==",
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.15.2.tgz",
+      "integrity": "sha512-efKkHF8c4kTKyBhBH2k0bZU4drqIic2jBYw/j1ixKOEEsa/WIiuUsdrBPD5uaRIoZ/91GzNCLiiV4ckIrf581g==",
       "requires": {
+        "@microsoft/applicationinsights-common": "^3.4.1",
         "@vscode/extension-telemetry": "^1.2.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -1367,7 +1367,7 @@
     "dotenv": "^16.4.5",
     "lodash": "^4.18.0",
     "uuid": "^8.3.2",
-    "vscode-extension-telemetry-wrapper": "^0.14.0",
+    "vscode-extension-telemetry-wrapper": "^0.15.1",
     "vscode-languageclient": "6.0.0-next.9",
     "vscode-languageserver-types": "3.16.0",
     "vscode-tas-client": "^0.1.84"

--- a/package.json
+++ b/package.json
@@ -1367,7 +1367,7 @@
     "dotenv": "^16.4.5",
     "lodash": "^4.18.0",
     "uuid": "^8.3.2",
-    "vscode-extension-telemetry-wrapper": "^0.15.1",
+    "vscode-extension-telemetry-wrapper": "^0.15.2",
     "vscode-languageclient": "6.0.0-next.9",
     "vscode-languageserver-types": "3.16.0",
     "vscode-tas-client": "^0.1.84"


### PR DESCRIPTION
Update vscode-extension-telemetry-wrapper to 0.15.1.

This picks up the wrapper release that removes the vulnerable uuid dependency and uses Node's built-in crypto.randomUUID().