### PR TITLE
Remove uuid dependency, use built-in crypto.randomUUID()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "compare-versions": "^4.1.4",
         "dotenv": "^16.4.5",
         "lodash": "^4.18.0",
-        "uuid": "^8.3.2",
         "vscode-extension-telemetry-wrapper": "^0.15.2",
         "vscode-languageclient": "6.0.0-next.9",
         "vscode-languageserver-types": "3.16.0",
@@ -2892,14 +2891,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
-    "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/vscode-extension-telemetry-wrapper": {
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/vscode-extension-telemetry-wrapper/-/vscode-extension-telemetry-wrapper-0.15.2.tgz",
@@ -5388,11 +5379,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vscode-extension-telemetry-wrapper": {
       "version": "0.15.2",

--- a/package.json
+++ b/package.json
@@ -1366,7 +1366,6 @@
     "compare-versions": "^4.1.4",
     "dotenv": "^16.4.5",
     "lodash": "^4.18.0",
-    "uuid": "^8.3.2",
     "vscode-extension-telemetry-wrapper": "^0.15.2",
     "vscode-languageclient": "6.0.0-next.9",
     "vscode-languageserver-types": "3.16.0",

--- a/src/progressImpl.ts
+++ b/src/progressImpl.ts
@@ -1,14 +1,14 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
-import { v4 } from "uuid";
+import * as crypto from "crypto";
 import { CancellationToken, CancellationTokenSource, Disposable, EventEmitter, ProgressLocation,
     StatusBarAlignment, StatusBarItem, window, workspace } from "vscode";
 import { IProgressProvider, IProgressReporter } from "./progressAPI";
 
 const STATUS_COMMAND: string = "java.show.server.task.status";
 class ProgressReporter implements IProgressReporter {
-    private _id: string = v4();
+    private _id: string = crypto.randomUUID();
     private _jobName: string;
     private _progressLocation: ProgressLocation | { viewId: string };
     private _cancellable: boolean = false;


### PR DESCRIPTION
Replace the `uuid` package with Node.js built-in `crypto.randomUUID()`. This removes the `uuid` dependency entirely, addressing the Dependabot alert for uuid v8 and avoiding compatibility issues with uuid v14+.

Supersedes #1630.

### Changes
- `src/progressImpl.ts`: Replace `import { v4 } from "uuid"` with `import * as crypto from "crypto"` and use `crypto.randomUUID()`
- `package.json`: Remove `uuid` from dependencies
- `package-lock.json`: Regenerated without uuid

### Context
- `crypto.randomUUID()` is available in Node.js 19.1+ (stable) and is the recommended replacement
- Same approach used in [vscode-extension-telemetry-wrapper#55](https://github.com/Eskibear/vscode-extension-telemetry-wrapper/pull/55)