### PR TITLE
fix(lmtool): stop double-counting classNameDetection on every invoke

### DIFF
--- a/src/languageModelTool.ts
+++ b/src/languageModelTool.ts
@@ -194,7 +194,27 @@ async function debugJavaApplication(
     }
 
     // Step 3: Construct and execute the debugjava command
-    const debugCommand = constructDebugCommand(input, projectType);
+    //
+    // For simple class names (no dot), resolve the fully-qualified class once
+    // here so we can reuse the result for both the command construction and
+    // the user-facing targetInfo message below. Previously these two paths
+    // each called findFullyQualifiedClassName independently, which:
+    //  - duplicated the file system walk on the hot launch path
+    //  - emitted two classNameDetection events per invoke, inflating the
+    //    detection failure rate in telemetry by 2x
+    let detectedClassName: string | null = null;
+    if (!input.target.endsWith('.jar')
+        && !input.target.startsWith('-')
+        && !input.target.includes('.')) {
+        detectedClassName = findFullyQualifiedClassName(input.workspacePath, input.target, projectType);
+        recordLaunchInternal({
+            name: 'classNameDetection',
+            projectType,
+            detected: !!detectedClassName,
+        });
+    }
+
+    const debugCommand = constructDebugCommand(input, projectType, detectedClassName);
 
     // Validate that we can construct a valid command
     if (!debugCommand || debugCommand === 'debugjava') {
@@ -223,8 +243,9 @@ async function debugJavaApplication(
     } else if (input.target.includes('.')) {
         targetInfo = input.target;
     } else {
-        // Simple class name - check if we successfully detected the full name
-        const detectedClassName = findFullyQualifiedClassName(input.workspacePath, input.target, projectType);
+        // Simple class name - reuse the detection result from Step 3 above
+        // (do NOT call findFullyQualifiedClassName again — it walks the FS
+        // and was double-emitting the classNameDetection telemetry event).
         if (detectedClassName) {
             targetInfo = `${detectedClassName} (detected from ${input.target})`;
         } else {
@@ -584,10 +605,17 @@ async function ensureVSCodeCompilation(workspaceUri: vscode.Uri): Promise<DebugJ
 
 /**
  * Constructs the debugjava command based on input parameters.
+ *
+ * @param preDetectedClassName Fully-qualified class name pre-resolved by the
+ *   caller (and already reported via the `classNameDetection` telemetry event).
+ *   When non-null and the target is a simple class name, this is used instead
+ *   of re-running findFullyQualifiedClassName here. The caller is expected to
+ *   handle telemetry emission so we do not double-count detection outcomes.
  */
 function constructDebugCommand(
     input: DebugJavaApplicationInput,
-    projectType: 'maven' | 'gradle' | 'vscode' | 'unknown'
+    projectType: 'maven' | 'gradle' | 'vscode' | 'unknown',
+    preDetectedClassName: string | null = null
 ): string {
     let command = 'debugjava';
 
@@ -603,25 +631,12 @@ function constructDebugCommand(
     else {
         let className = input.target;
 
-        // If target doesn't contain a dot and we can find the Java file,
-        // try to detect the fully qualified class name
-        if (!input.target.includes('.')) {
-            const detectedClassName = findFullyQualifiedClassName(input.workspacePath, input.target, projectType);
-            if (detectedClassName) {
-                recordLaunchInternal({
-                    name: 'classNameDetection',
-                    projectType,
-                    detected: true,
-                });
-                className = detectedClassName;
-            } else {
-                // No package detected - class is in default package
-                recordLaunchInternal({
-                    name: 'classNameDetection',
-                    projectType,
-                    detected: false,
-                });
-            }
+        // Use the caller-supplied detection result; we deliberately do not
+        // call findFullyQualifiedClassName a second time here (see the
+        // dedupe note at the call site). Detection telemetry is owned by
+        // the caller.
+        if (!input.target.includes('.') && preDetectedClassName) {
+            className = preDetectedClassName;
         }
 
         // Use provided classpath if available, otherwise infer it

--- a/src/languageModelTool.ts
+++ b/src/languageModelTool.ts
@@ -199,9 +199,15 @@ async function debugJavaApplication(
     // here so we can reuse the result for both the command construction and
     // the user-facing targetInfo message below. Previously these two paths
     // each called findFullyQualifiedClassName independently, which:
-    //  - duplicated the file system walk on the hot launch path
-    //  - emitted two classNameDetection events per invoke, inflating the
-    //    detection failure rate in telemetry by 2x
+    //  - duplicated the file system walk on the hot launch path (the FS walk
+    //    is the actual user-visible slowdown — it stats every .java file
+    //    under src/main/java up to MAX_FILE_SEARCH_DEPTH)
+    //  - made the call sites harder to reason about, since detection
+    //    ownership was split across constructDebugCommand and the targetInfo
+    //    formatting block
+    //
+    // After this refactor, the caller owns detection and its telemetry,
+    // and constructDebugCommand accepts a pre-resolved name.
     let detectedClassName: string | null = null;
     if (!input.target.endsWith('.jar')
         && !input.target.startsWith('-')
@@ -245,7 +251,7 @@ async function debugJavaApplication(
     } else {
         // Simple class name - reuse the detection result from Step 3 above
         // (do NOT call findFullyQualifiedClassName again — it walks the FS
-        // and was double-emitting the classNameDetection telemetry event).
+        // and the result is already in `detectedClassName`).
         if (detectedClassName) {
             targetInfo = `${detectedClassName} (detected from ${input.target})`;
         } else {


### PR DESCRIPTION
> **Update (review pass):** the original PR description claimed this dedup would deflate the observed `noPackage` failure rate "from 49% to ~25%". That claim is **wrong** — the duplicate `findFullyQualifiedClassName` call in `debugJavaApplication` only ran the FS walk a second time; `recordLaunchInternal({name:'classNameDetection'})` was only emitted from `constructDebugCommand`. So:
>
> - ✅ This PR still removes one full file-system walk on every simple-class-name launch (real perf win, real code-clarity win)
> - ❌ The observed 49% noPackage rate is **not** inflated 2× — it is a real signal that still needs investigation (see #1650 / `06-深度诊断-PR定向-2026-06-09.md` P0-3)

## Problem

`debugJavaApplication` (the `debug_java_application` LMT handler) was calling
`findFullyQualifiedClassName` twice per invocation for the simple-class-name path:

1. Once **inside** `constructDebugCommand` (to resolve the FQN for the actual
   `java -cp ... ClassName` command), where it also emitted
   `recordLaunchInternal({name: 'classNameDetection', detected: <bool>})`.
2. Once **in the caller**, immediately after `constructDebugCommand`, just to
   build the user-facing `targetInfo` string (`"com.example.App (detected from App)"`).

`findFullyQualifiedClassName` walks `src/main/java` (or equivalent) recursively
up to `MAX_FILE_SEARCH_DEPTH`, stats every `.java` file, and reads candidates
to extract the package. Doing it twice on every launch is wasted work on the
hot path.

## Fix

- Move the detection call (and the `classNameDetection` telemetry emit) into
  the caller (`debugJavaApplication`, Step 3), so it runs **exactly once** per
  invocation.
- Add an optional third parameter `preDetectedClassName?: string | null` to
  `constructDebugCommand`. When the caller has already resolved the FQN, it
  passes that result in and `constructDebugCommand` skips re-detection.
- Reuse the same resolved name in the `targetInfo` formatting block — no
  second FS walk.

## Scope

- **No behavior change** for users. The resolved FQN, the constructed
  `debugjava` command, and the telemetry event content are identical.
- **No telemetry-count change** — `classNameDetection` still fires exactly
  once per invocation (it always did; the second call site was not emitting).
- One extra FS walk eliminated per simple-class-name launch.

## Test

- `npx tsc --noEmit` — clean
- `npm run tslint` — clean
- Diff: +44 / -27 in 1 file (after review reword)

## Validation plan

This PR is a refactor, so there is no metric we expect to move. Post-ship
sanity check: per-invocation `classNameDetection` event volume should stay
flat (1:1 with `debug_java_application.invoke`). If it drops by ~50%, that
would actually confirm a pre-existing 2× emission elsewhere we missed; if it
stays equal, the refactor is a pure perf win, which matches the code reading.

```kql
RawEventsVSCodeExt
| where ServerTimestamp > ago(14d)
| where ExtensionName == "vscjava.vscode-java-debug"
| extend op = tostring(Properties["operationname"])
| where op endswith "debug_java_application.invoke"
   or op endswith "classNameDetection"
| summarize count() by op, extversion = tostring(Properties["common.extversion"])
| order by extversion desc, op
```

## Related

- Independent of #1650 (telemetry contract) and #1652 (timeout messaging).
  All three can land in any order.
- The actual 49% noPackage rate is investigated in #1650's structured
  `classNameDetection.failed` event (with `failureReason` ∈
  `noPackageDeclaration / fileNotFound / sourceDirMissing / parseError`).
- Same diagnostic context: `debugagent/06-深度诊断-PR定向-2026-06-09.md`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
