### PR TITLE
chore: remove unused uuid type dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "@types/lodash": "^4.17.13",
         "@types/mocha": "^10.0.9",
         "@types/node": "^14.18.63",
-        "@types/uuid": "^8.3.4",
         "@types/vscode": "1.95.0",
         "@vscode/test-electron": "^3.1.0",
         "mocha": "^10.8.2",
@@ -308,12 +307,6 @@
       "version": "14.18.63",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "dev": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "node_modules/@types/vscode": {
@@ -3491,12 +3484,6 @@
       "version": "14.18.63",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "dev": true
-    },
-    "@types/uuid": {
-      "version": "8.3.4",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz",
-      "integrity": "sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==",
       "dev": true
     },
     "@types/vscode": {

--- a/package.json
+++ b/package.json
@@ -1388,7 +1388,6 @@
     "@types/lodash": "^4.17.13",
     "@types/mocha": "^10.0.9",
     "@types/node": "^14.18.63",
-    "@types/uuid": "^8.3.4",
     "@types/vscode": "1.95.0",
     "@vscode/test-electron": "^3.1.0",
     "mocha": "^10.8.2",


### PR DESCRIPTION
Removes the unused `@types/uuid` development dependency. Its latest version is a deprecated stub that installs `uuid` transitively, so this supersedes [#1670](https://github.com/microsoft/vscode-java-debug/pull/1670).

Validation:
- `npm run tslint`
- `npm test` (29 passing)
- VSIX package and isolated installation
- `npm audit --omit=dev --audit-level=high`