### PR TITLE
chore: limit Dependabot development updates to minor and patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,12 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    allow:
+      - dependency-type: "production"
+      - dependency-type: "development"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     # CI restores packages from the Central Feed Service, which withholds
     # upstream versions until they are roughly a week old (measured at ~6.8
     # days; both the packument entry and the tarball return 404 before then).

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,9 @@ updates:
         update-types:
           - "version-update:semver-minor"
           - "version-update:semver-patch"
+    commit-message:
+      prefix: "chore(deps)"
+      prefix-development: "chore(dev-deps)"
     # CI restores packages from the Central Feed Service, which withholds
     # upstream versions until they are roughly a week old (measured at ~6.8
     # days; both the packument entry and the tarball return 404 before then).


### PR DESCRIPTION
## Summary

- Allow ordinary npm development-dependency version updates for minor and patch releases only. Major toolchain migrations should be scheduled and reviewed deliberately rather than arriving as routine dependency bumps.
- Keep production dependency version updates eligible at every semantic version level.
- Preserve automatic security-update eligibility, including for development dependencies: GitHub documents that `update-types` in `allow` rules limits version updates only, not security updates.
- Set npm Dependabot commit messages and PR titles to use `chore(deps): ...` for production dependencies and `chore(dev-deps): ...` for development dependencies.

## Scope

Only `.github/dependabot.yml` changes. The daily npm schedule, 10-day npm cooldown and Central Feed Service rationale comments remain unchanged. All GitHub Actions settings remain unchanged, including the weekly schedule, grouping and 7-day cooldown.

This PR starts from `main` and contains no package manifest, lockfile or TypeScript changes and no automerge rules.

## Reference

[GitHub's Dependabot `allow` reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#allow) supports combining `dependency-type` with `update-types`; omitting `update-types` keeps all version update types eligible for that rule.

[GitHub's Dependabot `commit-message` reference](https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#commit-message) supports separate production and development prefixes for npm and applies them to both commit messages and PR titles.