### PR TITLE
fix(deps-dev): update vulnerable js-yaml resolutions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1601,10 +1601,21 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -2780,10 +2791,11 @@
       }
     },
     "node_modules/tslint/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -4378,9 +4390,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "requires": {
         "argparse": "^2.0.1"
@@ -5170,9 +5182,9 @@
           "dev": true
         },
         "js-yaml": {
-          "version": "3.14.2",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-          "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+          "version": "3.15.2",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+          "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",


### PR DESCRIPTION
## Summary
Update only the two development-only `js-yaml` resolutions in [package-lock.json](https://github.com/microsoft/vscode-java-debug/blob/main/package-lock.json):

| Dependency path | Before | After | Existing parent range |
|---|---|---|---|
| `mocha -> js-yaml` | 4.1.1 | 4.3.2 | `^4.1.0` |
| `tslint -> js-yaml` | 3.14.2 | 3.15.2 | `^3.13.1` |

Generated with `npm update js-yaml --package-lock-only --ignore-scripts --no-fund`. Both versions satisfy the existing parent ranges and are outside every open advisory range. Preserves lockfile v2 and its legacy dependency section; no package additions/removals, unrelated dependency changes, manifest changes, or overrides.

## Dependabot alerts
The refreshed, fully paginated inventory contains exactly these six open alerts:

| Advisory | Severity | Alerts |
|---|---|---|
| [GHSA-5p4m-2wfm-xmqj](https://github.com/advisories/GHSA-5p4m-2wfm-xmqj) | High | [66](https://github.com/microsoft/vscode-java-debug/security/dependabot/66), [65](https://github.com/microsoft/vscode-java-debug/security/dependabot/65) |
| [GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m) | High | [56](https://github.com/microsoft/vscode-java-debug/security/dependabot/56), [55](https://github.com/microsoft/vscode-java-debug/security/dependabot/55) |
| [GHSA-h67p-54hq-rp68](https://github.com/advisories/GHSA-h67p-54hq-rp68) | Medium | [52](https://github.com/microsoft/vscode-java-debug/security/dependabot/52), [51](https://github.com/microsoft/vscode-java-debug/security/dependabot/51) |

## Validation
On Windows with Node 22.15.1 / npm 10.9.2 and Java 21:
- `npm ci --no-fund`, `npm run tslint`, `npm test` (57 passing; one intentional POSIX-only skip), `npm run build`, and `vsce package` (VSCE 3.6.1) passed.
- Verified the exact lockfile graph delta, both parent semver constraints, and every locked `js-yaml` instance against all six alert ranges.
- `npm audit --omit=dev --package-lock-only --json`: zero findings. Full audit retains only the pre-existing low-severity `diff` advisory [GHSA-73rr-hh4g-fpgx](https://github.com/advisories/GHSA-73rr-hh4g-fpgx), mapped to already auto-dismissed alerts [23](https://github.com/microsoft/vscode-java-debug/security/dependabot/23) and [26](https://github.com/microsoft/vscode-java-debug/security/dependabot/26); intentionally unchanged. No alert states were modified.

## CI and review
For head `b31dd22153b5975b0ac0536878e04f532593b745`, [GitHub Actions CI](https://github.com/microsoft/vscode-java-debug/actions/runs/34204754274) completed successfully on Linux, macOS, and Windows; `license/cla` also passed. No external commit statuses or Azure check runs were registered on this head. The [Azure Pipelines bot notice](https://github.com/microsoft/vscode-java-debug/pull/1695#issuecomment-5581805597) says an authorized `/azp run` comment may be required; no trigger comment was posted, so Azure validation is not claimed.

Copilot review was requested after CI passed and [completed](https://github.com/microsoft/vscode-java-debug/pull/1695#pullrequestreview-5139310869) with "Copilot wasn't able to review any files in this pull request." Human review is still required.