### PR TITLE
build: validate dependency updates through CFS

### DIFF
--- a/.azure-pipelines/ci.yml
+++ b/.azure-pipelines/ci.yml
@@ -16,6 +16,17 @@ trigger:
   branches:
     include:
       - main
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - package.json
+      - package-lock.json
+      - .azure-pipelines/ci.yml
+      - .azure-pipelines/npm-cfs.yml
+      - .azure-pipelines/npm-cfs-variables.yml
 extends:
   template: v1/1ES.Unofficial.PipelineTemplate.yml@1esPipelines
   parameters:
@@ -33,8 +44,22 @@ extends:
     stages:
       - stage: Build
         jobs:
+          - job: CFSValidation
+            displayName: Validate dependencies from CFS
+            condition: eq(variables['Build.Reason'], 'PullRequest')
+            steps:
+              - checkout: self
+                fetchTags: false
+              - task: NodeTool@0
+                displayName: Use Node 20.x
+                inputs:
+                  versionSpec: 20.x
+              - template: /.azure-pipelines/npm-cfs.yml@self
+              - script: npm ci --ignore-scripts --prefer-online --cache "$(Agent.TempDirectory)/npm-cache"
+                displayName: Validate npm dependencies from CFS
           - job: Job_1
             displayName: VSCode-Java-Debug-CI
+            condition: ne(variables['Build.Reason'], 'PullRequest')
             templateContext:
               outputs:
                 - output: pipelineArtifact

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,27 +5,6 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: "production"
-      - dependency-type: "development"
-        update-types:
-          - "version-update:semver-minor"
-          - "version-update:semver-patch"
-    commit-message:
-      prefix: "chore(deps)"
-      prefix-development: "chore(dev-deps)"
-    # CI restores packages from the Central Feed Service, which withholds
-    # upstream versions until they are roughly a week old (measured at ~6.8
-    # days; both the packument entry and the tarball return 404 before then).
-    # Dependabot's built-in cooldown is only 3 days, so bumps otherwise land in
-    # a window where the feed 404s and the build fails. 10 days leaves margin
-    # in case the feed's ingestion lag drifts.
-    cooldown:
-      default-days: 10
   - package-ecosystem: "github-actions"
     directory: "/"
     groups:


### PR DESCRIPTION
## Summary
- remove scheduled npm Dependabot version updates while keeping grouped GitHub Actions updates
- add a PR-only CFS validation job for the npm package lockfile
- keep the existing full build, VSIX packaging, and artifact publication for non-PR runs
- trigger the CFS gate only when dependency inputs or CFS pipeline configuration changes

## Why
The ADO build restores packages through CFS, where newly published upstream versions may not be available immediately. A dependency PR can therefore pass GitHub Actions but fail the ADO build with a CFS 404. A dedicated PR gate checks actual feed availability before merge without running the full extension build.

## ADO
Updated [`microsoft.vscode-java-debug-ci-vsix`](https://dev.azure.com/mseng/VSJava/_build?definitionId=16490) to use `main`, the `microsoft (7)` GitHub connection, and automatic PR validation without requiring an `/azp run` comment.

There are no Gradle, Maven, or NuGet dependency manifests in this repository. The gate covers the actual CFS consumer here: npm.